### PR TITLE
add hash and eq to MDC

### DIFF
--- a/tests/datacontract/md_test.py
+++ b/tests/datacontract/md_test.py
@@ -33,3 +33,40 @@ def test_manual_step_md_parsing(tmp_path, md, url, bread):
         assert s.url.endswith("file.md")
     assert s.keywords == (bread or "file")
     assert s.md == "Text"
+
+
+@pytest.mark.parametrize(
+    ["a", "b", "outcome"],
+    [
+        pytest.param(
+            MarkdownDataContract(md="md", keywords="key words", url="u r l"),
+            {"md": "md", "keywords": "key words", "url": "u r l"},
+            True,
+            id="mdc==dict",
+        ),
+        pytest.param(
+            MarkdownDataContract(md="md", keywords="key words", url="u r l"),
+            MarkdownDataContract(md="md", keywords="key words", url="u r l"),
+            True,
+            id="mdc==mdc",
+        ),
+        pytest.param(
+            MarkdownDataContract(md="mds", keywords="key words", url="u r l"),
+            {"md": "md", "keywords": "key words", "url": "u r l"},
+            False,
+            id="mdc!=dict",
+        ),
+        pytest.param(
+            MarkdownDataContract(md="md", keywords="key words", url="u r l"),
+            MarkdownDataContract(md="mds", keywords="key words", url="u r l"),
+            False,
+            id="mdc!=mdc",
+        ),
+    ],
+)
+def test_equality_and_hash(a, b, outcome):
+    obj_equal = a == b
+    if isinstance(a, MarkdownDataContract) and isinstance(b, MarkdownDataContract):
+        hash_equal = hash(a) == hash(b)
+        assert obj_equal == hash_equal
+    assert obj_equal == outcome

--- a/tests/datacontract/md_test.py
+++ b/tests/datacontract/md_test.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+import wurzel
 from wurzel import MarkdownDataContract
 
 
@@ -35,6 +36,16 @@ def test_manual_step_md_parsing(tmp_path, md, url, bread):
     assert s.md == "Text"
 
 
+class MDCChild(MarkdownDataContract):
+    pass
+
+
+class SameDefPyd(wurzel.datacontract.PydanticModel):
+    md: str
+    keywords: str
+    url: str
+
+
 @pytest.mark.parametrize(
     ["a", "b", "outcome"],
     [
@@ -51,6 +62,18 @@ def test_manual_step_md_parsing(tmp_path, md, url, bread):
             id="mdc==mdc",
         ),
         pytest.param(
+            MarkdownDataContract(md="md", keywords="key words", url="u r l"),
+            MDCChild(md="md", keywords="key words", url="u r l"),
+            True,
+            id="mdc==mdcChild",
+        ),
+        pytest.param(
+            MarkdownDataContract(md="md", keywords="key words", url="u r l"),
+            SameDefPyd(md="md", keywords="key words", url="u r l"),
+            True,
+            id="mdc==Compatible",
+        ),
+        pytest.param(
             MarkdownDataContract(md="mds", keywords="key words", url="u r l"),
             {"md": "md", "keywords": "key words", "url": "u r l"},
             False,
@@ -61,6 +84,18 @@ def test_manual_step_md_parsing(tmp_path, md, url, bread):
             MarkdownDataContract(md="mds", keywords="key words", url="u r l"),
             False,
             id="mdc!=mdc",
+        ),
+        pytest.param(
+            MarkdownDataContract(md="mds", keywords="key words", url="u r l"),
+            MDCChild(md="md", keywords="key words", url="u r l"),
+            False,
+            id="mdc!=mdcChild",
+        ),
+        pytest.param(
+            MarkdownDataContract(md="md", keywords="key words", url="u r l"),
+            SameDefPyd(md="mds", keywords="key words", url="u r l"),
+            False,
+            id="mdc!=Compatible",
         ),
     ],
 )

--- a/wurzel/datacontract/common.py
+++ b/wurzel/datacontract/common.py
@@ -54,16 +54,3 @@ class MarkdownDataContract(PydanticModel):
             url=str(find_first(_RE_URL, md, url_prefix + path.as_posix())),
             keywords=str(find_first(_RE_TOPIC, md, path.name.split(".")[0])),
         )
-
-    def __hash__(self) -> int:
-        return hash(f"{self.url}::{self.keywords}::{self.md}")
-
-    def __eq__(self, other: object) -> bool:
-        #pylint: disable-next=not-an-iterable
-        for field in self.model_fields:
-            other_value = getattr(other, field, None)
-            if isinstance(other, dict):
-                other_value = other.get(field, None)
-            if getattr(self, field) != other_value:
-                return False
-        return True

--- a/wurzel/datacontract/common.py
+++ b/wurzel/datacontract/common.py
@@ -54,3 +54,16 @@ class MarkdownDataContract(PydanticModel):
             url=str(find_first(_RE_URL, md, url_prefix + path.as_posix())),
             keywords=str(find_first(_RE_TOPIC, md, path.name.split(".")[0])),
         )
+
+    def __hash__(self) -> int:
+        return hash(f"{self.url}::{self.keywords}::{self.md}")
+
+    def __eq__(self, other: object) -> bool:
+        #pylint: disable-next=not-an-iterable
+        for field in self.model_fields:
+            other_value = getattr(other, field, None)
+            if isinstance(other, dict):
+                other_value = other.get(field, None)
+            if getattr(self, field) != other_value:
+                return False
+        return True

--- a/wurzel/datacontract/datacontract.py
+++ b/wurzel/datacontract/datacontract.py
@@ -106,6 +106,7 @@ class PydanticModel(pydantic.BaseModel, DataModel):
         raise NotImplementedError(f"Can not load {model_type}")
 
     def __hash__(self) -> int:
+        # pylint: disable-next=not-an-iterable
         return hash("".join([getattr(self, name) for name in self.model_fields]))
 
     def __eq__(self, other: object) -> bool:

--- a/wurzel/datacontract/datacontract.py
+++ b/wurzel/datacontract/datacontract.py
@@ -106,7 +106,7 @@ class PydanticModel(pydantic.BaseModel, DataModel):
         raise NotImplementedError(f"Can not load {model_type}")
 
     def __hash__(self) -> int:
-        return hash("".join([getattr(self, name) for name in self.model_fields_set]))
+        return hash("".join([getattr(self, name) for name in self.model_fields]))
 
     def __eq__(self, other: object) -> bool:
         # pylint: disable-next=not-an-iterable

--- a/wurzel/datacontract/datacontract.py
+++ b/wurzel/datacontract/datacontract.py
@@ -104,3 +104,16 @@ class PydanticModel(pydantic.BaseModel, DataModel):
             return data
 
         raise NotImplementedError(f"Can not load {model_type}")
+
+    def __hash__(self) -> int:
+        return hash("".join([getattr(self, name) for name in self.model_fields_set]))
+
+    def __eq__(self, other: object) -> bool:
+        # pylint: disable-next=not-an-iterable
+        for field in self.model_fields:
+            other_value = getattr(other, field, None)
+            if isinstance(other, dict):
+                other_value = other.get(field, None)
+            if getattr(self, field) != other_value:
+                return False
+        return True


### PR DESCRIPTION
## Description
MarkdownDataContract is not able to be compared to one-another.
This is a trivial problem. 


## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run the linter and ensured the code is formatted correctly
- NOT APPLICABLE [x] I have updated the documentation accordingly
