### PR TITLE
fix/markdown-code-enhance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,4 @@ Temporary Items
 
 # UV
 uv.lock
+.idea

--- a/tests/datacontract/md_test.py
+++ b/tests/datacontract/md_test.py
@@ -21,6 +21,16 @@ from wurzel import MarkdownDataContract
             "bread,butter",
         ),
         ("\n---\n\n\ntopics:bread,butter\n\n---\nText", "", "bread,butter"),
+        (
+            "\n---\n\n\ntopics:bread,butter\n\n---\nText\nurl:url_body",
+            "",
+            "bread,butter",
+        ),
+        (
+            "\n---\n\n\ntopics:bread,butter\nurl:url_header\n\n---\nText",
+            "url_header",
+            "bread,butter",
+        ),
     ],
 )
 def test_manual_step_md_parsing(tmp_path, md, url, bread):
@@ -33,7 +43,11 @@ def test_manual_step_md_parsing(tmp_path, md, url, bread):
         assert s.url.startswith("SPACE/")
         assert s.url.endswith("file.md")
     assert s.keywords == (bread or "file")
-    assert s.md == "Text"
+
+    if "url:url_body" in md:
+        assert s.md == "Text\nurl:url_body"
+    else:
+        assert s.md == "Text"
 
 
 class MDCChild(MarkdownDataContract):

--- a/wurzel/steps/qdrant/step.py
+++ b/wurzel/steps/qdrant/step.py
@@ -216,7 +216,7 @@ class QdrantConnectorStep(
     @staticmethod
     def get_available_hashes(text: str, encoding: str = "utf-8") -> dict:
         """Compute `n` hashes for a given input text based.
-         
+
         The number `n` depends on the optionally installed python libs.
         For now only TLSH (Trend Micro Locality Sensitive Hash) is supported
 


### PR DESCRIPTION
## Description
We optionally extract meta-data from a header in ManualMarkdown Files.
The current implementation scans the entire document for the keys 'url', 'keywords' etc.

This needs to be changed so that only the header part of the document is searched for these.

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run the linter and ensured the code is formatted correctly

