### PR TITLE
remove step_executor import in wurzel.step

### DIFF
--- a/tests/cli/gen_cli_call_test.py
+++ b/tests/cli/gen_cli_call_test.py
@@ -5,7 +5,7 @@
 import pytest
 
 from wurzel.cli import generate_cli_call
-from wurzel.step import BaseStepExecutor, PrometheusStepExecutor
+from wurzel.step_executor import BaseStepExecutor, PrometheusStepExecutor
 from wurzel.steps.manual_markdown import ManualMarkdownStep
 
 

--- a/tests/cli/main_test.py
+++ b/tests/cli/main_test.py
@@ -9,7 +9,7 @@ import typer
 import wurzel
 import wurzel.steps
 from wurzel.cli import _main as main
-from wurzel.step import BaseStepExecutor, PrometheusStepExecutor
+from wurzel.step_executor import BaseStepExecutor, PrometheusStepExecutor
 from wurzel.steps.manual_markdown import ManualMarkdownStep
 
 

--- a/tests/import_test.py
+++ b/tests/import_test.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG (opensource@telekom.de)
+#
+# SPDX-License-Identifier: Apache-2.0
 """Test for cyclic imports in utils"""
 
 

--- a/tests/import_test.py
+++ b/tests/import_test.py
@@ -5,12 +5,12 @@
 
 
 def test_import_utils():
-    pass
+    import wurzel.utils # noqa: F401 I001
 
 
 def test_import_steps():
-    pass
+    import wurzel.steps # noqa: F401 I001
 
 
 def test_import_utils_meta_settings():
-    pass
+    import wurzel.utils.meta_settings # noqa: F401 I001

--- a/tests/import_test.py
+++ b/tests/import_test.py
@@ -1,0 +1,13 @@
+"""Test for cyclic imports in utils"""
+
+
+def test_import_utils():
+    pass
+
+
+def test_import_steps():
+    pass
+
+
+def test_import_utils_meta_settings():
+    pass

--- a/tests/step_executor/allows_extra_settings_test.py
+++ b/tests/step_executor/allows_extra_settings_test.py
@@ -8,11 +8,11 @@ import pytest
 
 from wurzel.exceptions import StepFailed
 from wurzel.step import (
-    BaseStepExecutor,
     MarkdownDataContract,
     Settings,
     TypedStep,
 )
+from wurzel.step_executor import BaseStepExecutor
 
 
 class MySettings(Settings):

--- a/tests/step_executor/basic_test.py
+++ b/tests/step_executor/basic_test.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from wurzel.step import BaseStepExecutor, MarkdownDataContract, NoSettings, TypedStep
+from wurzel.step import MarkdownDataContract, NoSettings, TypedStep
+from wurzel.step_executor import BaseStepExecutor
 
 
 class MyStep(TypedStep[NoSettings, MarkdownDataContract, list[MarkdownDataContract]]):

--- a/tests/step_executor/correlation_id_test.py
+++ b/tests/step_executor/correlation_id_test.py
@@ -8,7 +8,8 @@ import asgi_correlation_id
 import pytest
 
 from wurzel.exceptions import StepFailed
-from wurzel.step import BaseStepExecutor, MarkdownDataContract, TypedStep
+from wurzel.step import MarkdownDataContract, TypedStep
+from wurzel.step_executor import BaseStepExecutor
 
 
 class OkExc(Exception):

--- a/tests/step_executor/env_encapsulation_test.py
+++ b/tests/step_executor/env_encapsulation_test.py
@@ -7,11 +7,13 @@ from pydantic import ValidationError
 
 from wurzel.exceptions import EnvSettingsError
 from wurzel.step import (
-    BaseStepExecutor,
-    PrometheusStepExecutor,
     PydanticModel,
     Settings,
     TypedStep,
+)
+from wurzel.step_executor import (
+    BaseStepExecutor,
+    PrometheusStepExecutor,
 )
 from wurzel.step_executor.base_executor import step_env_encapsulation
 

--- a/tests/step_executor/finalize_test.py
+++ b/tests/step_executor/finalize_test.py
@@ -4,7 +4,8 @@
 
 import pytest
 
-from wurzel.step import BaseStepExecutor, NoSettings, PydanticModel, TypedStep
+from wurzel.step import NoSettings, PydanticModel, TypedStep
+from wurzel.step_executor import BaseStepExecutor
 
 
 class NiecheException(Exception):

--- a/tests/step_executor/history_test.py
+++ b/tests/step_executor/history_test.py
@@ -4,8 +4,9 @@
 
 import pytest
 
-from wurzel.step import BaseStepExecutor, MarkdownDataContract, NoSettings, TypedStep
+from wurzel.step import MarkdownDataContract, NoSettings, TypedStep
 from wurzel.step.history import History, step_history
+from wurzel.step_executor import BaseStepExecutor
 
 
 class OkExc(Exception):

--- a/wurzel/adapters/dvc_adapter.py
+++ b/wurzel/adapters/dvc_adapter.py
@@ -10,8 +10,8 @@ import yaml
 
 import wurzel
 import wurzel.cli
-from wurzel.step import BaseStepExecutor, TypedStep
-from wurzel.step_executor.prometheus_executor import PrometheusStepExecutor
+from wurzel.step import TypedStep
+from wurzel.step_executor import PrometheusStepExecutor, BaseStepExecutor
 
 
 class DvcDict(TypedDict):

--- a/wurzel/adapters/dvc_adapter.py
+++ b/wurzel/adapters/dvc_adapter.py
@@ -11,7 +11,7 @@ import yaml
 import wurzel
 import wurzel.cli
 from wurzel.step import TypedStep
-from wurzel.step_executor import PrometheusStepExecutor, BaseStepExecutor
+from wurzel.step_executor import BaseStepExecutor, PrometheusStepExecutor
 
 
 class DvcDict(TypedDict):

--- a/wurzel/step/__init__.py
+++ b/wurzel/step/__init__.py
@@ -4,7 +4,6 @@
 
 from ..datacontract import MarkdownDataContract, PanderaDataFrameModel, PydanticModel
 from ..path import PathToFolderWithBaseModels
-from ..step_executor import BaseStepExecutor, PrometheusStepExecutor
 from .history import step_history  # noqa: F401
 from .settings import NoSettings, Settings
 from .step import Step
@@ -22,6 +21,4 @@ __all__ = [
     "PathToFolderWithBaseModels",
     "NoSettings",
     "Settings",
-    "BaseStepExecutor",
-    "PrometheusStepExecutor",
 ]


### PR DESCRIPTION
## Description
Due to changes in imports in version 0.8.0 it was discovered that certain ways of using wurzel were creating cyclic imports.
This addresses this issue

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run the linter and ensured the code is formatted correctly
- [x] I have updated the documentation accordingly


<!--
Thank you for your contribution! Your efforts help improve the project and are greatly appreciated.-->
