### PR TITLE
hotfix: add a lock for Misteltoe markdownRenderers

### DIFF
--- a/wurzel/steps/docling/docling_step.py
+++ b/wurzel/steps/docling/docling_step.py
@@ -33,6 +33,7 @@ from mistletoe import Document, HTMLRenderer
 
 from wurzel.datacontract.common import MarkdownDataContract
 from wurzel.step.typed_step import TypedStep
+from wurzel.utils.to_markdown.html2md import MD_RENDER_LOCK
 
 from .settings import DoclingSettings
 
@@ -98,7 +99,7 @@ class DoclingStep(TypedStep[DoclingSettings, None, list[MarkdownDataContract]]):
             md_text (str): The raw Markdown input string.
 
         """
-        with CleanMarkdownRenderer() as renderer:
+        with MD_RENDER_LOCK, CleanMarkdownRenderer() as renderer:
             ast = Document(md_text)
             cleaned = renderer.render(ast).replace("\n", "")
             soup = BeautifulSoup(cleaned, "html.parser")

--- a/wurzel/utils/semantic_splitter.py
+++ b/wurzel/utils/semantic_splitter.py
@@ -16,6 +16,7 @@ from mistletoe.token import Token
 
 from wurzel.datacontract import MarkdownDataContract
 from wurzel.exceptions import MarkdownException
+from wurzel.utils.to_markdown.html2md import MD_RENDER_LOCK
 
 if TYPE_CHECKING:
     import spacy
@@ -208,7 +209,7 @@ class SemanticSplitter:
     def _render_doc(self, doc: MisDocument) -> str:
         """Render Mistletoe Markdown Document."""
         try:
-            with WurzelMarkdownRenderer() as renderer:
+            with MD_RENDER_LOCK, WurzelMarkdownRenderer() as renderer:
                 return renderer.render(doc)  # type: ignore[no-any-return]
         except Exception as e:
             raise MarkdownException(e) from e

--- a/wurzel/utils/to_markdown/html2md.py
+++ b/wurzel/utils/to_markdown/html2md.py
@@ -6,6 +6,7 @@ import platform
 import re
 import subprocess
 import tempfile
+import threading
 from pathlib import Path
 
 # Related third-party imports
@@ -19,6 +20,7 @@ from mistletoe.span_token import Image
 from wurzel.exceptions import InvalidPlatform, MarkdownConvertFailed
 
 # pylint: disable=c-extension-no-member
+MD_RENDER_LOCK = threading.Lock()
 
 
 def __get_html2md() -> Path:
@@ -106,7 +108,7 @@ def remove_images(markdown: str) -> str:
     """
 
     def _to_markdown(doc: Document) -> str:
-        with MarkdownRenderer() as renderer:
+        with MD_RENDER_LOCK, MarkdownRenderer() as renderer:
             rendered = renderer.render(doc)
         # Adjust for excessive newlines
         return re.sub(r"\n\n+", "\n\n", rendered)


### PR DESCRIPTION
## Description
Since Misteltoe is not threadsafe we need to account for this.
For more information see: https://github.com/miyuchina/mistletoe/issues/210

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have run the linter and ensured the code is formatted correctly
- [x] I have updated the documentation accordingly


<!--
Thank you for your contribution! Your efforts help improve the project and are greatly appreciated.-->
