### PR TITLE
fix: add html2md binary for WindowsAmd64 devices

### DIFF
--- a/wurzel/utils/to_markdown/html2md.py
+++ b/wurzel/utils/to_markdown/html2md.py
@@ -26,6 +26,7 @@ def __get_html2md() -> Path:
         "Linux_x86_64": Path(__file__).parent / "html2md",
         "Darwin_arm64": Path(__file__).parent / "html2md_darwin_arm",
         "Darwin_x86_64": Path(__file__).parent / "html2md_darwin_amd64",
+        "Windows_AMD64": Path(__file__).parent / "html2md_win_amd64",
     }
     fallback = default_path.get(f"{platform.uname().system}_{platform.uname().machine}", None)
     if fallback is None:


### PR DESCRIPTION
## Description
html2md was not working on windows devices. This will resolve that for x86 Windows devices

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run the linter and ensured the code is formatted correctly
- [ ] I have updated the documentation accordingly


<!--
Thank you for your contribution! Your efforts help improve the project and are greatly appreciated.-->
