### PR TITLE
fix: usage of __call__ in BaseStepExecutor

### DIFF
--- a/tests/step_executor/executor_prometheus_test.py
+++ b/tests/step_executor/executor_prometheus_test.py
@@ -3,8 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from wurzel.datacontract.common import MarkdownDataContract
+from wurzel.step.typed_step import TypedStep
 from wurzel.step_executor import PrometheusStepExecutor
 
+class DummyStep(TypedStep[None, None, MarkdownDataContract]):
+    def run(self, inpt: None) -> MarkdownDataContract:
+        return MarkdownDataContract(md="md", keywords="", url="")
 
 def test_create_metrics():
     executor = PrometheusStepExecutor()
@@ -20,3 +25,9 @@ def test_context_manager_singelton():
     with PrometheusStepExecutor() as exc:
         with PrometheusStepExecutor() as exc2:
             assert exc == exc2
+def test_setting_of_counters():
+    with PrometheusStepExecutor() as exc:
+        exc(DummyStep, None, None)
+        assert exc.counter_results.collect()[0].samples[0].value == 1.0
+        exc(DummyStep, None, None)
+        assert exc.counter_results.collect()[0].samples[0].value == 2.0

--- a/tests/step_executor/executor_prometheus_test.py
+++ b/tests/step_executor/executor_prometheus_test.py
@@ -7,9 +7,11 @@ from wurzel.datacontract.common import MarkdownDataContract
 from wurzel.step.typed_step import TypedStep
 from wurzel.step_executor import PrometheusStepExecutor
 
+
 class DummyStep(TypedStep[None, None, MarkdownDataContract]):
     def run(self, inpt: None) -> MarkdownDataContract:
         return MarkdownDataContract(md="md", keywords="", url="")
+
 
 def test_create_metrics():
     executor = PrometheusStepExecutor()
@@ -25,6 +27,8 @@ def test_context_manager_singelton():
     with PrometheusStepExecutor() as exc:
         with PrometheusStepExecutor() as exc2:
             assert exc == exc2
+
+
 def test_setting_of_counters():
     with PrometheusStepExecutor() as exc:
         exc(DummyStep, None, None)

--- a/wurzel/step_executor/base_executor.py
+++ b/wurzel/step_executor/base_executor.py
@@ -347,7 +347,10 @@ class BaseStepExecutor:
             log.info(f"{self.__class__.__name__} - done: {step_cls.__name__}")
             correlation_id.set(None)
 
-    __call__ = execute_step
+    def __call__(
+        self, step_cls: type[TypedStep], inputs: Optional[set[PathToFolderWithBaseModels]], output_dir: Optional[PathToFolderWithBaseModels]
+    ):
+        return self.execute_step(step_cls, inputs, output_dir)
 
     def __enter__(self) -> Self:
         return self


### PR DESCRIPTION
## Description
the __call__ method of BaseStepExecutor did not respect inheritance


## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run the linter and ensured the code is formatted correctly
- [ ] I have updated the documentation accordingly


<!--
Thank you for your contribution! Your efforts help improve the project and are greatly appreciated.-->
