### PR TITLE
ci: add secrets pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,4 @@ test_file.py
 # Local development files
 #   These files are used for local development and should not be included in version control.
 tmp.py
+tmp/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,10 @@ repos:
     hooks:
       - id: validate-pyproject
 
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
 
   - repo: https://github.com/fsfe/reuse-tool
     rev: v5.0.2

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -49,7 +49,7 @@ TENANTS:
     MANUALMARKDOWNSTEP:
       FOLDER_PATH: data/
     WURZEL_PIPELINE: "pipelinedemo:pipeline"
-    secret_name: wurzel-demo
+    secret_name: wurzel-demo #pragma: allowlist secret
 
 
 ALLOW_EXTRA_SETTINGS: False # setting you may enbale when you want to allow additional environment variables in the same Step Namespace although they are not expected from the Settings (Not recommended for prod or staging)

--- a/tests/steps/embedding/conftest.py
+++ b/tests/steps/embedding/conftest.py
@@ -18,7 +18,7 @@ GET_RESULT_INFO_DICT = {
     "max_client_batch_size": 512,
     "tokenization_workers": 2,
     "version": "1.2.0",
-    "sha": "3edace22f22d5dab32d421034683183953fe5061",
+    "sha": "3edace22f22d5dab32d421034683183953fe5061",  # pragma: allowlist secret
     "docker_label": "sha-3edace2",
 }
 

--- a/tests/steps/qdrant/tlsh_test.py
+++ b/tests/steps/qdrant/tlsh_test.py
@@ -11,9 +11,9 @@ from wurzel.utils import HAS_TLSH
 @pytest.mark.parametrize(
     "text,expected_hash",
     [
-        ("example_text_1", "5840445c9d0a1457627eaa4718d48bbc5071782ac6df6d85dfef7f82a4dc01a6"),
-        ("example_text_2", "69cee72aa104c9a62e6ceb4e7cebdffef3ce0f385cbb807c4a587149bd9fc028"),
-        ("example_text_3", "7fde1636e509f9a34474f6dcdaddb66db7b09871ed6f934a384b3fb3b491a24e"),
+        ("example_text_1", "5840445c9d0a1457627eaa4718d48bbc5071782ac6df6d85dfef7f82a4dc01a6"),  # pragma: allowlist secret
+        ("example_text_2", "69cee72aa104c9a62e6ceb4e7cebdffef3ce0f385cbb807c4a587149bd9fc028"),  # pragma: allowlist secret
+        ("example_text_3", "7fde1636e509f9a34474f6dcdaddb66db7b09871ed6f934a384b3fb3b491a24e"),  # pragma: allowlist secret
     ],
 )
 def test_tlsh_hash_same_output(text: str, expected_hash: str):


### PR DESCRIPTION
It might be a good idea to make pre-commit hooks the default, since new contributors won’t have them enabled by default @merren-fx 