### PR TITLE
ci: pytest version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dependencies= [
     "joblib>=1.4.0",
     "lxml==5.2.*",
     "marshmallow<4.0.0",
-
 ]
 
 [project.optional-dependencies]
@@ -78,7 +77,7 @@ lint = [
     "ruff==0.9.10",
 ]
 test = [
-    "pytest==8.*",
+    "pytest==8.4.*",
     "pytest-asyncio==0.23.*",
     "pytest-cov==4.*",
     "pytest-html==4.*",

--- a/tests/logging/extra_test.py
+++ b/tests/logging/extra_test.py
@@ -48,5 +48,6 @@ def test_make_dict_serializable(in_data, expected):
     res = _make_dict_serializable(in_data)
     if expected is not None:
         if isinstance(in_data, Iterable):
-            return all(d in res for d in expected)
-        assert expected == res
+            assert all(d in res for d in expected)
+        else:
+            assert expected == res


### PR DESCRIPTION
fixes: 


=========================== short test summary info ============================
FAILED tests/logging/extra_test.py::test_make_dict_serializable[str] - Failed: Expected None, but test returned True. Did you mean to use `assert` instead of `return`?
FAILED tests/logging/extra_test.py::test_make_dict_serializable[list] - Failed: Expected None, but test returned True. Did you mean to use `assert` instead of `return`?
FAILED tests/logging/extra_test.py::test_make_dict_serializable[dict] - Failed: Expected None, but test returned True. Did you mean to use `assert` instead of `return`?
FAILED tests/logging/extra_test.py::test_make_dict_serializable[set] - Failed: Expected None, but test returned True. Did you mean to use `assert` instead of `return`?
======= 4 failed, 382 passed, 7 skipped, 10 warnings in 62.66s (0:01:02) =======