### PR TITLE
fix: scraperapi concurrent

### DIFF
--- a/wurzel/steps/scraperapi/settings.py
+++ b/wurzel/steps/scraperapi/settings.py
@@ -16,6 +16,7 @@ class ScraperAPISettings(Settings):
     """Settings of ScraperAPIStep. Mainly the list of https://docs.scraperapi.com/python/credits-and-requests."""
 
     API: str = "https://api.scraperapi.com/"
+    RETRY: int = 5
     TOKEN: str = ""
     TIMEOUT: int = 61.0
     XPATH: str = "//main"
@@ -25,6 +26,6 @@ class ScraperAPISettings(Settings):
     WAIT_FOR_SELECTOR: str = "#cookies-notification-accept-cookie"
     COUNTRY_CODE: str = "en"
     RENDER: bool = True
-    PREMIUM: bool = True
+    PREMIUM: bool = False
     ULTRA_PREMIUM: bool = False
     SCREENSHOT: bool = False

--- a/wurzel/steps/scraperapi/settings.py
+++ b/wurzel/steps/scraperapi/settings.py
@@ -5,16 +5,26 @@
 """interacts with the scraperAPI service and converts the retrieved Documents to Markdown."""
 
 # Standard library imports
+from pydantic import Field
+
 from wurzel.step.settings import Settings
 
 # Local application/library specific imports
 
 
 class ScraperAPISettings(Settings):
-    """Settings of ScraperAPIStep."""
+    """Settings of ScraperAPIStep. Mainly the list of https://docs.scraperapi.com/python/credits-and-requests."""
 
     API: str = "https://api.scraperapi.com/"
     TOKEN: str = ""
-    TIMEOUT: int = 30.0
+    TIMEOUT: int = 61.0
     XPATH: str = "//main"
-    CONCURRENCY_NUM: int = 1
+    CONCURRENCY_NUM: int = Field(gt=0, default=1)
+    DEVICE_TYPE: str = "desktop"
+    FOLLOW_REDIRECT: bool = True
+    WAIT_FOR_SELECTOR: str = "#cookies-notification-accept-cookie"
+    COUNTRY_CODE: str = "en"
+    RENDER: bool = True
+    PREMIUM: bool = True
+    ULTRA_PREMIUM: bool = False
+    SCREENSHOT: bool = False

--- a/wurzel/steps/scraperapi/settings.py
+++ b/wurzel/steps/scraperapi/settings.py
@@ -17,3 +17,4 @@ class ScraperAPISettings(Settings):
     TOKEN: str = ""
     TIMEOUT: int = 30.0
     XPATH: str = "//main"
+    CONCURRENCY_NUM: int = 1

--- a/wurzel/steps/scraperapi/step.py
+++ b/wurzel/steps/scraperapi/step.py
@@ -25,20 +25,23 @@ log = logging.getLogger(__name__)
 
 
 class ScraperAPIStep(TypedStep[ScraperAPISettings, list[UrlItem], list[MarkdownDataContract]]):
-    """Data Source for md files from a configurable path."""
+    """ScraperAPIStep uses the ScraperAPI service to srape the html by the given url through list[UrlItem].
+    this html gets filtered and transformed to MarkdownDataContract.
+    """
 
     def run(self, inpt: list[UrlItem]) -> list[MarkdownDataContract]:
         def fetch_and_process(url_item: UrlItem):
-            log.debug("scraping")
             payload = {
                 "api_key": self.settings.TOKEN,
                 "url": url_item.url,
-                "device_type": "desktop",
-                "follow_redirect": "true",
-                "wait_for_selector": "#cookies-notification-accept-cookie",
-                "country_code": "hr",
-                "render": "true",
-                "premium": "true",
+                "device_type": self.settings.DEVICE_TYPE,
+                "follow_redirect": str(self.settings.FOLLOW_REDIRECT).lower(),
+                "wait_for_selector": self.settings.WAIT_FOR_SELECTOR,
+                "country_code": self.settings.COUNTRY_CODE,
+                "render": str(self.settings.RENDER).lower(),
+                "premium": str(self.settings.PREMIUM).lower(),
+                "ultra_premium": str(self.settings.ULTRA_PREMIUM).lower(),
+                "screenshot": str(self.settings.SCREENSHOT).lower(),
             }
             try:
                 r = requests.get(self.settings.API, params=payload, timeout=self.settings.TIMEOUT)
@@ -62,14 +65,14 @@ class ScraperAPIStep(TypedStep[ScraperAPISettings, list[UrlItem], list[MarkdownD
             try:
                 md = to_markdown(self._filter_body(r.text))
             except (KeyError, IndexError):
-                logging.warning("website does not have the searched xpath", extra={"filter": self.settings.XPATH, "url": url_item.url})
+                log.warning("website does not have the searched xpath", extra={"filter": self.settings.XPATH, "url": url_item.url})
                 return None
 
+            progress_bar.update(1)
             return MarkdownDataContract(md=md, url=url_item.url, keywords=url_item.title)
 
-        results = Parallel(n_jobs=self.settings.CONCURRENCY_NUM, backend="threading")(
-            delayed(fetch_and_process)(item) for item in tqdm(inpt)
-        )
+        with tqdm(total=len(inpt), desc="Processing URLs") as progress_bar:
+            results = Parallel(n_jobs=self.settings.CONCURRENCY_NUM, backend="threading")(delayed(fetch_and_process)(item) for item in inpt)
 
         filtered_results = [res for res in results if res]
         if not filtered_results:

--- a/wurzel/steps/scraperapi/step.py
+++ b/wurzel/steps/scraperapi/step.py
@@ -10,6 +10,7 @@ import logging
 import lxml
 import requests
 from joblib import Parallel, delayed
+from requests.adapters import HTTPAdapter, Retry
 from tqdm import tqdm
 
 from wurzel.datacontract import MarkdownDataContract
@@ -30,7 +31,12 @@ class ScraperAPIStep(TypedStep[ScraperAPISettings, list[UrlItem], list[MarkdownD
     """
 
     def run(self, inpt: list[UrlItem]) -> list[MarkdownDataContract]:
-        def fetch_and_process(url_item: UrlItem):
+        def fetch_and_process(url_item: UrlItem, recursion_depth=0):
+            session = requests.Session()
+            retries = Retry(
+                total=self.settings.RETRY, backoff_factor=0.1, raise_on_status=False, status_forcelist=[403, 500, 502, 503, 504]
+            )
+            session.mount("https://", HTTPAdapter(max_retries=retries))
             payload = {
                 "api_key": self.settings.TOKEN,
                 "url": url_item.url,
@@ -44,7 +50,7 @@ class ScraperAPIStep(TypedStep[ScraperAPISettings, list[UrlItem], list[MarkdownD
                 "screenshot": str(self.settings.SCREENSHOT).lower(),
             }
             try:
-                r = requests.get(self.settings.API, params=payload, timeout=self.settings.TIMEOUT)
+                r = session.get(self.settings.API, params=payload, timeout=self.settings.TIMEOUT)
                 r.raise_for_status()
             except requests.exceptions.ReadTimeout:
                 log.warning(
@@ -55,18 +61,19 @@ class ScraperAPIStep(TypedStep[ScraperAPISettings, list[UrlItem], list[MarkdownD
             except requests.exceptions.HTTPError:
                 log.warning(
                     "Crawling failed",
-                    extra={
-                        "url": url_item.url,
-                        "error": r.text,
-                        "status": r.status_code,
-                    },
+                    extra={"url": url_item.url, "error": r.text, "status": r.status_code, "retries": self.settings.RETRY},
                 )
                 return None
             try:
                 md = to_markdown(self._filter_body(r.text))
             except (KeyError, IndexError):
-                log.warning("website does not have the searched xpath", extra={"filter": self.settings.XPATH, "url": url_item.url})
-                return None
+                if recursion_depth > self.settings.RETRY:
+                    log.warning("xpath retry failed", extra={"filter": self.settings.XPATH, "url": url_item.url})
+                    return None
+                log.warning(
+                    "website does not have the searched xpath, retrying", extra={"filter": self.settings.XPATH, "url": url_item.url}
+                )
+                return fetch_and_process(url_item, recursion_depth=recursion_depth + 1)
 
             progress_bar.update(1)
             return MarkdownDataContract(md=md, url=url_item.url, keywords=url_item.title)

--- a/wurzel/steps/scraperapi/step.py
+++ b/wurzel/steps/scraperapi/step.py
@@ -9,6 +9,7 @@ import logging
 
 import lxml
 import requests
+from joblib import Parallel, delayed
 from tqdm import tqdm
 
 from wurzel.datacontract import MarkdownDataContract
@@ -27,14 +28,17 @@ class ScraperAPIStep(TypedStep[ScraperAPISettings, list[UrlItem], list[MarkdownD
     """Data Source for md files from a configurable path."""
 
     def run(self, inpt: list[UrlItem]) -> list[MarkdownDataContract]:
-        result = []
-        for url_item in tqdm(inpt):
+        def fetch_and_process(url_item: UrlItem):
             log.debug("scraping")
             payload = {
                 "api_key": self.settings.TOKEN,
                 "url": url_item.url,
-                "render": "true",
                 "device_type": "desktop",
+                "follow_redirect": "true",
+                "wait_for_selector": "#cookies-notification-accept-cookie",
+                "country_code": "hr",
+                "render": "true",
+                "premium": "true",
             }
             try:
                 r = requests.get(self.settings.API, params=payload, timeout=self.settings.TIMEOUT)
@@ -44,7 +48,7 @@ class ScraperAPIStep(TypedStep[ScraperAPISettings, list[UrlItem], list[MarkdownD
                     "Crawling failed due to timeout",
                     extra={"url": url_item.url},
                 )
-                continue
+                return None
             except requests.exceptions.HTTPError:
                 log.warning(
                     "Crawling failed",
@@ -54,14 +58,24 @@ class ScraperAPIStep(TypedStep[ScraperAPISettings, list[UrlItem], list[MarkdownD
                         "status": r.status_code,
                     },
                 )
-                continue
+                return None
+            try:
+                md = to_markdown(self._filter_body(r.text))
+            except (KeyError, IndexError):
+                logging.warning("website does not have the searched xpath", extra={"filter": self.settings.XPATH, "url": url_item.url})
+                return None
 
-            md = to_markdown(self._filter_body(r.text))
-            keywords = url_item.title
-            result.append(MarkdownDataContract(md=md, url=url_item.url, keywords=keywords))
-        if not result:
+            return MarkdownDataContract(md=md, url=url_item.url, keywords=url_item.title)
+
+        results = Parallel(n_jobs=self.settings.CONCURRENCY_NUM, backend="threading")(
+            delayed(fetch_and_process)(item) for item in tqdm(inpt)
+        )
+
+        filtered_results = [res for res in results if res]
+        if not filtered_results:
             raise StepFailed("no results from scraperAPI")
-        return result
+
+        return filtered_results
 
     def _filter_body(self, html: str) -> str:
         tree: lxml.html = lxml.html.fromstring(html)


### PR DESCRIPTION
## Description
ScraperAPI may get blocked by the website, such that a retry is helpful from an other server.
## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ x New and existing unit tests pass locally with my changes
- [x] I have run the linter and ensured the code is formatted correctly
- [ ] I have updated the documentation accordingly

