### PR TITLE
fix: pypi release

### DIFF
--- a/DIRECT_REQUIREMENTS.txt
+++ b/DIRECT_REQUIREMENTS.txt
@@ -1,0 +1,1 @@
+de_core_news_sm @ https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-3.7.0/de_core_news_sm-3.7.0-py3-none-any.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /usr/app
 
 COPY pyproject.toml ./
+COPY DIRECT_REQUIREMENTS.txt ./
 
 RUN --mount=type=cache,target=/tmp/.cache/uv,id=uv-cache \
     uv sync --no-install-project
@@ -49,7 +50,8 @@ RUN --mount=type=cache,target=/tmp/.cache/uv,id=uv-cache \
 
 COPY wurzel ./wurzel
 RUN --mount=type=cache,target=/tmp/.cache/uv,id=uv-cache \
-    uv sync --inexact
+    uv sync --inexact && \
+    uv pip install -r DIRECT_REQUIREMENTS.txt
 
 FROM python:${PYTHON_VERSION}-slim AS production
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ build: install
 
 $(VENV)/touchfile: pyproject.toml $(UV)
 	$(UV) --no-progress pip install -r pyproject.toml --all-extras
+	@echo "Installing direct dependencies from DIRECT_REQUIREMENTS.txt..."
+	$(UV) --no-progress pip install -r DIRECT_REQUIREMENTS.txt
 	@$(shell if [ "$(OS)" = "Windows_NT" ]; then echo type nul > $(VENV)\\touchfile; else echo touch $(VENV)/touchfile; fi)
 $(PY):
 	$(SYSTEM_PYTHON) -m venv $(VENV)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,145 @@
+# Installation Guide
+
+This guide covers installing Wurzel and its dependencies, including handling the special case of direct dependencies that cannot be installed through PyPI.
+
+## Basic Installation
+
+To get started with Wurzel, install the library using pip:
+
+```bash
+pip install wurzel
+```
+
+## Direct Dependencies (spaCy Model)
+
+Due to PyPI restrictions on direct dependencies, some components require manual installation. This primarily affects the German spaCy model used for semantic text splitting.
+
+### Manual Installation
+
+If you plan to use the semantic text splitting functionality (e.g., `SemanticSplitter`), you'll need to manually install the German spaCy model:
+
+```bash
+pip install https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-3.7.0/de_core_news_sm-3.7.0-py3-none-any.whl
+```
+
+### Using DIRECT_REQUIREMENTS.txt
+
+If you're working with the source code, you can install from the provided requirements file:
+
+```bash
+pip install -r DIRECT_REQUIREMENTS.txt
+```
+
+
+## Optional Dependencies
+
+Wurzel supports various optional features through extras:
+
+### Vector Database Support
+
+```bash
+# For Qdrant vector database
+pip install wurzel[qdrant]
+
+# For Milvus vector database
+pip install wurzel[milvus]
+```
+
+### Document Processing
+
+```bash
+# For PDF document processing with Docling
+pip install wurzel[docling]
+```
+
+### Development Tools
+
+```bash
+# For linting and code quality tools
+pip install wurzel[lint]
+
+# For testing framework and tools
+pip install wurzel[test]
+
+# For documentation generation
+pip install wurzel[docs]
+```
+
+### Install Everything
+
+```bash
+# Install all optional dependencies
+pip install wurzel[all]
+
+# Don't forget the direct dependencies!
+pip install -r DIRECT_REQUIREMENTS.txt
+```
+
+## Development Installation
+
+For development work, use the provided Makefile:
+
+```bash
+# Install all dependencies including development tools
+make install
+
+# Run tests
+make test
+
+# Run linting
+make lint
+
+# Generate documentation
+make documentation
+```
+
+## Docker Installation
+
+The Docker image includes all dependencies automatically:
+
+```bash
+# Pull the latest image
+docker pull ghcr.io/telekom/wurzel:latest
+
+# Or build locally
+docker build -t wurzel .
+```
+
+## Troubleshooting
+
+### spaCy Model Issues
+
+If you encounter issues with the spaCy model:
+
+1. Verify the model is installed:
+   ```bash
+   python -c "import spacy; nlp = spacy.load('de_core_news_sm'); print('Model loaded successfully')"
+   ```
+
+2. Reinstall the model if needed:
+   ```bash
+   pip uninstall de-core-news-sm
+   pip install https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-3.7.0/de_core_news_sm-3.7.0-py3-none-any.whl
+   ```
+
+### Environment Issues
+
+- Ensure you're using Python 3.11 or 3.12
+- Consider using a virtual environment:
+  ```bash
+  python -m venv .venv
+  source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+  pip install wurzel
+  ```
+
+## Why Direct Dependencies?
+
+PyPI has restrictions on packages that include direct dependencies to external URLs for security reasons. The spaCy German model is hosted on GitHub releases rather than PyPI, requiring manual installation.
+
+This approach ensures:
+- Security compliance with PyPI guidelines
+- Ability to publish to PyPI without restrictions
+- Clear separation of concerns between core functionality and external models
+- Flexibility in model versioning and updates
+
+For more information about this limitation, see the [PyPI documentation on direct dependencies](https://packaging.python.org/specifications/core-metadata/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dependencies= [
     "lxml==5.2.*",
     "marshmallow<4.0.0",
     "hera >=5.20.1",
-    "de-core-news-sm @ https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-3.7.0/de_core_news_sm-3.7.0-py3-none-any.whl",
 ]
 
 [project.optional-dependencies]
@@ -94,7 +93,7 @@ docs = [
     "mkdocstrings[python]"
 ]
 
-all = ["wurzel[qdrant,milvus,tlsh,docling,argo]"]
+all = ["wurzel[qdrant,milvus,tlsh,docling,spacy]"]
 dev = ["wurzel[lint,test,all]"]
 
 [build-system]


### PR DESCRIPTION
## Description
<!--Please include a summary of the changes and the related issue. Please also include relevant motivation and context.-->

```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         Can't have direct dependency: de-core-news-sm@                         
         https://github.com/explosion/spacy-models/releases/download/de_core_new
         s_sm-3.7.0/de_core_news_sm-3.7.0-py3-none-any.whl. See                 
         https://packaging.python.org/specifications/core-metadata for more     
         information.   
```



<!--
Thank you for your contribution! Your efforts help improve the project and are greatly appreciated.-->
