### PR TITLE
feat: Adding tokenizer abstraction to handle OpenAI's tiktoken and HF tokenizers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies= [
     "pandera==0.20.3",
     "mdformat==0.7.17",
     "spacy==3.7.5",
-    "tiktoken==0.7.0",
     "joblib>=1.4.0",
     "lxml==5.2.*",
     "marshmallow<4.0.0",
@@ -61,7 +60,12 @@ docling = [
 milvus = [
     "pymilvus==2.5.14",
 ]
-
+openai = [
+    "tiktoken==0.7.0",
+]
+transformers = [
+    "transformers",
+]
 # TLSH (Trend Micro Locality Sensitive Hash)
 # Note: Official TLSH repo: https://github.com/trendmicro/tlsh
 # - The latest release (4.12.0) requires installation from source, which fails.
@@ -93,7 +97,7 @@ docs = [
     "mkdocstrings[python]"
 ]
 
-all = ["wurzel[qdrant,milvus,tlsh,docling,argo]"]
+all = ["wurzel[qdrant,milvus,tlsh,docling,argo,openai,transformers]"]
 dev = ["wurzel[lint,test,all]"]
 
 [build-system]

--- a/tests/utils/tokenizers_test.py
+++ b/tests/utils/tokenizers_test.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG (opensource@telekom.de)
+#
+# SPDX-License-Identifier: Apache-2.0
+import importlib.util
+
+import pytest
+
+from wurzel.utils.tokenizers import HFTokenizer, TiktokenTokenizer, Tokenizer
+
+# Helpers for skip conditions
+tiktoken_missing = importlib.util.find_spec("tiktoken") is None
+transformers_missing = importlib.util.find_spec("transformers") is None
+
+
+@pytest.mark.skipif(tiktoken_missing, reason="tiktoken not installed")
+def test_from_name_routes_to_tiktoken_for_openai_name():
+    tok = Tokenizer.from_name("gpt2")  # OpenAI alias; tiktoken knows it
+    assert isinstance(tok, TiktokenTokenizer)
+
+
+@pytest.mark.skipif(tiktoken_missing, reason="tiktoken not installed")
+def test_tiktoken_encode_decode_known_ids():
+    tok = Tokenizer.from_name("gpt-4o-mini")  # uses tiktoken.encoding_for_model
+    text = "Hello world"
+    ids = tok.encode(text)
+    assert ids == [13225, 2375]  # GPT-2 / r50k_base stable tokens
+    assert tok.decode(ids) == text
+
+
+@pytest.mark.skipif(tiktoken_missing, reason="tiktoken not installed")
+def test_tiktoken_accepts_raw_encoding_name():
+    tok = Tokenizer.from_name("cl100k_base")
+    assert isinstance(tok, TiktokenTokenizer)
+    text = "ChatGPT is great."
+    ids = tok.encode(text)
+    assert isinstance(ids, list) and all(isinstance(i, int) for i in ids)
+    assert tok.decode(ids) == text
+
+
+@pytest.mark.skipif(transformers_missing, reason="transformers not installed")
+def test_from_name_routes_to_hf_for_non_openai_name():
+    tok = Tokenizer.from_name("intfloat/multilingual-e5-large")  # not an OpenAI model
+    assert isinstance(tok, HFTokenizer)
+    text = "Hello world"
+    ids = tok.encode(text)
+    decoded = tok.decode(ids)
+    assert decoded == "<s> Hello world</s>"
+
+
+@pytest.mark.skipif(transformers_missing, reason="transformers not installed")
+def test_hf_adapter_known_ids_gpt2():
+    from transformers import AutoTokenizer
+
+    hf = AutoTokenizer.from_pretrained("intfloat/multilingual-e5-large")
+    tok = HFTokenizer(hf)
+
+    text = "Hello world"
+    ids = tok.encode(text)
+    assert ids == [0, 35378, 8999, 2]  # E5 tokens

--- a/wurzel/steps/splitter.py
+++ b/wurzel/steps/splitter.py
@@ -26,7 +26,9 @@ class SplitterSettings(Settings):
     TOKEN_COUNT_MIN: int = Field(64, gt=0)
     TOKEN_COUNT_MAX: int = Field(1024, gt=1)
     TOKEN_COUNT_BUFFER: int = Field(32, gt=0)
-    TOKENIZER_MODEL: str = Field("gpt-3.5-turbo", description="The tokenizer model to use for splitting documents.")
+    TOKENIZER_MODEL: str = Field(
+        "gpt-3.5-turbo", description="The tokenizer model to use for splitting documents (supported: tiktoken and HF transformers)."
+    )
 
 
 log = getLogger(__name__)

--- a/wurzel/utils/tokenizers.py
+++ b/wurzel/utils/tokenizers.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG (opensource@telekom.de)
+#
+# SPDX-License-Identifier: Apache-2.0
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import tiktoken
+    import transformers
+
+
+class Tokenizer(ABC):
+    """Abstract base class for text tokenizers.
+
+    This interface provides a common API (`encode`, `decode`) for both
+    OpenAI's `tiktoken.Encoding` objects and Hugging Face tokenizers.
+
+    Subclasses must implement `encode` and `decode`.
+
+    The `from_name` class method will attempt to create the correct
+    tokenizer type automatically based on the given model or encoding name.
+    """
+
+    @abstractmethod
+    def encode(self, text: str) -> list[int]:
+        """Convert text into a list of token IDs.
+
+        Args:
+            text: The input string to tokenize.
+
+        Returns:
+            A list of integer token IDs.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def decode(self, tokens: list[int]) -> str:
+        """Convert a list of token IDs back into a string.
+
+        Args:
+            tokens: A list of integer token IDs.
+
+        Returns:
+            The decoded string.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def from_name(cls, name: str) -> "Tokenizer":
+        """Instantiate a tokenizer by model or encoding name.
+
+        The method first tries to load an OpenAI tokenizer using
+        `tiktoken.encoding_for_model(name)`. If that fails, it falls back
+        to loading a Hugging Face tokenizer with
+        `transformers.AutoTokenizer.from_pretrained(name)`.
+
+        Args:
+            name: Model or encoding name. Can be an OpenAI model (e.g.,
+                "gpt-4o", "gpt-3.5-turbo"), an OpenAI encoding name
+                (e.g., "cl100k_base"), or a Hugging Face model name
+                (e.g., "bert-base-uncased").
+
+        Returns:
+            An instance of `TiktokenTokenizer` or `HFTokenizer`.
+        """
+        try:
+            import tiktoken  # pylint: disable=import-outside-toplevel
+
+            # First try by model name
+            encoding = tiktoken.encoding_for_model(name)
+            return TiktokenTokenizer(encoding)
+        except (KeyError, ValueError):
+            try:
+                # If it's a raw encoding name like "cl100k_base"
+                encoding = tiktoken.get_encoding(name)
+                return TiktokenTokenizer(encoding)
+            except (KeyError, ValueError):
+                # Default to HF tokenizer
+                from transformers import AutoTokenizer  # pylint: disable=import-outside-toplevel
+
+                hf_tok = AutoTokenizer.from_pretrained(name)
+                return HFTokenizer(hf_tok)
+
+
+class TiktokenTokenizer(Tokenizer):
+    """Adapter for OpenAI's `tiktoken.Encoding` tokenizer."""
+
+    def __init__(self, encoding: "tiktoken.core.Encoding"):
+        """Initialize a TiktokenTokenizer.
+
+        Args:
+            encoding: A `tiktoken.Encoding` instance.
+        """
+        self._enc = encoding
+
+    def encode(self, text: str, **kwargs) -> list[int]:
+        """Tokenize text into token IDs."""
+        return self._enc.encode(text, **kwargs)
+
+    def decode(self, tokens: list[int], **kwargs) -> str:
+        """Convert token IDs back into text."""
+        return self._enc.decode(tokens, **kwargs)
+
+
+class HFTokenizer(Tokenizer):
+    """Adapter for Hugging Face `PreTrainedTokenizerBase` objects."""
+
+    def __init__(self, tokenizer: "transformers.PreTrainedTokenizerBase"):
+        """Initialize an HFTokenizer.
+
+        Args:
+            tokenizer: A Hugging Face tokenizer instance.
+            skip_special_tokens: Whether to remove special tokens during decoding.
+        """
+        self._tok = tokenizer
+
+    def encode(self, text: str, **kwargs) -> list[int]:
+        """Tokenize text into token IDs."""
+        return self._tok.encode(text, **kwargs)
+
+    def decode(self, tokens: list[int], **kwargs) -> str:
+        """Convert token IDs back into text."""
+        return self._tok.decode(tokens, **kwargs)


### PR DESCRIPTION
Adding tokenizer abstraction to handle OpenAI's tiktoken and HF tokenizers

## Description

- Adding abstract tokenizer class with `from_name` method that can initialize HF and OAI tokenizers
- Fixes https://github.com/telekom/wurzel/issues/106

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run the linter and ensured the code is formatted correctly
- [ ] I have updated the documentation accordingly


<!--
Thank you for your contribution! Your efforts help improve the project and are greatly appreciated.-->
