### PR TITLE
fix: YAML-Metadata for Markdown files following the Jekyll standard (fixes #101)

### DIFF
--- a/docs/datacontract/common.md
+++ b/docs/datacontract/common.md
@@ -1,0 +1,10 @@
+# Data contracts
+
+Data contracts are the primarily inputs and outputs of pipeline steps, e.g., Markdown documents.
+
+## MarkdownDataContract
+
+::: wurzel.datacontract.common.MarkdownDataContract
+    options:
+      show_source: false
+      heading_level: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies= [
     "lxml==5.2.*",
     "marshmallow<4.0.0",
     "hera >=5.20.1",
+    "PyYAML",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies= [
     "lxml==5.2.*",
     "marshmallow<4.0.0",
     "hera >=5.20.1",
-    "PyYAML",
+    "pyyaml>=6.0.2",
 ]
 
 [project.optional-dependencies]

--- a/tests/datacontract/md_test.py
+++ b/tests/datacontract/md_test.py
@@ -15,20 +15,20 @@ from wurzel.step import MarkdownDataContract
         ("---\n\n   url: myurl\n---\nText", "myurl", ""),
         ("---\n\n\t url: myurl\n---\nText", "", ""),  # invalid YAML, ignore metadata
         ("---\nurl: myurl\n---\nText", "myurl", ""),
-        ("---\n\nurl: myurl\n\ntopics: bread\n---\nText", "myurl", "bread"),
+        ("---\n\nurl: myurl\n\nkeywords: bread\n---\nText", "myurl", "bread"),
         (
-            "---\n\nurl: myurl\n\ntopics: bread,butter\n---\nText",
+            "---\n\nurl: myurl\n\nkeywords: bread,butter\n---\nText",
             "myurl",
             "bread,butter",
         ),
-        ("---\n\n\ntopics: bread,butter\n---\nText", "", "bread,butter"),
+        ("---\n\n\nkeywords: bread,butter\n---\nText", "", "bread,butter"),
         (
-            "---\n\n\ntopics: bread,butter\n\n---\nText\nurl:url_body",
+            "---\n\n\nkeywords: bread,butter\n\n---\nText\nurl:url_body",
             "",
             "bread,butter",
         ),
         (
-            "---\n\n\ntopics: bread,butter\nurl: url_header\n---\nText",
+            "---\n\n\nkeywords: bread,butter\nurl: url_header\n---\nText",
             "url_header",
             "bread,butter",
         ),

--- a/tests/datacontract/md_test.py
+++ b/tests/datacontract/md_test.py
@@ -11,23 +11,24 @@ from wurzel.step import MarkdownDataContract
 @pytest.mark.parametrize(
     "md,url,bread",
     [
-        ("\n---\n\nurl:myurl\n\n---\nText", "myurl", ""),
-        ("\n---\n\n   url:myurl\n\n---\nText", "myurl", ""),
-        ("\n---\n\n\t url:myurl\n\n---\nText", "myurl", ""),
-        ("\n---\n\nurl:myurl\n\ntopics:bread\n\n---\nText", "myurl", "bread"),
+        ("---\n\nurl: myurl\n---\nText", "myurl", ""),
+        ("---\n\n   url: myurl\n---\nText", "myurl", ""),
+        ("---\n\n\t url: myurl\n---\nText", "", ""),  # invalid YAML, ignore metadata
+        ("---\nurl: myurl\n---\nText", "myurl", ""),
+        ("---\n\nurl: myurl\n\ntopics: bread\n---\nText", "myurl", "bread"),
         (
-            "\n---\n\nurl:myurl\n\ntopics:bread,butter\n\n---\nText",
+            "---\n\nurl: myurl\n\ntopics: bread,butter\n---\nText",
             "myurl",
             "bread,butter",
         ),
-        ("\n---\n\n\ntopics:bread,butter\n\n---\nText", "", "bread,butter"),
+        ("---\n\n\ntopics: bread,butter\n---\nText", "", "bread,butter"),
         (
-            "\n---\n\n\ntopics:bread,butter\n\n---\nText\nurl:url_body",
+            "---\n\n\ntopics: bread,butter\n\n---\nText\nurl:url_body",
             "",
             "bread,butter",
         ),
         (
-            "\n---\n\n\ntopics:bread,butter\nurl:url_header\n\n---\nText",
+            "---\n\n\ntopics: bread,butter\nurl: url_header\n---\nText",
             "url_header",
             "bread,butter",
         ),
@@ -119,3 +120,72 @@ def test_equality_and_hash(a, b, outcome):
         hash_equal = hash(a) == hash(b)
         assert obj_equal == hash_equal
     assert obj_equal == outcome
+
+
+def test_table_not_metadata(tmp_path):
+    md = """some text
+
+| no | header |
+| --- | --- |
+| but a | table |
+
+some more text
+
+| no | header |
+| --- | --- |
+| but a | table |"""
+
+    f = tmp_path / "file.md"
+    f.write_text(md)
+    s = MarkdownDataContract.from_file(f, url_prefix="SPACE/")
+
+    assert s.md == md
+    assert s.url.startswith("SPACE/")
+    assert s.url.endswith("file.md")
+
+
+@pytest.mark.parametrize(
+    "header_md,body_md",
+    [
+        (
+            """---
+fo_ : ",
+-
+-
+#
+---
+""",
+            """# title
+some text
+
+some more text
+
+| no | header |
+| --- | --- |
+| but a | table |""",
+        ),  # YAML is invalid syntax
+        (
+            """---
+- foo
+- bar
+---
+""",
+            """# title
+some text
+
+some more text
+
+| no | header |
+| --- | --- |
+| but a | table |""",
+        ),  # YAML is a list not a dictionary
+    ],
+)
+def test_metadata_invalid_yaml_ignore_metadata(tmp_path, header_md, body_md):
+    f = tmp_path / "file.md"
+    f.write_text(header_md + "\n" + body_md)
+    s = MarkdownDataContract.from_file(f, url_prefix="SPACE/")
+
+    assert s.md == body_md
+    assert s.url.startswith("SPACE/")
+    assert s.url.endswith("file.md")

--- a/wurzel/datacontract/common.py
+++ b/wurzel/datacontract/common.py
@@ -98,9 +98,15 @@ class MarkdownDataContract(PydanticModel):
             md_body = md
             logger.info(f"MarkdownDataContract has no YAML metadata: {path}", extra={"path": path, "md": md})
 
+        if "topics" in metadata:
+            logger.warning(
+                "`topics` metadata field is deprecated and will be removed in a future release. Use `keywords` instead.",
+                category=DeprecationWarning,
+            )
+
         return MarkdownDataContract(
             md=md_body,
             # Extract metadata fields or use default value
             url=metadata.get("url", url_prefix + str(path.absolute())),
-            keywords=metadata.get("topics", path.name.split(".")[0]),
+            keywords=metadata.get("keywords", path.name.split(".")[0]),
         )

--- a/wurzel/datacontract/common.py
+++ b/wurzel/datacontract/common.py
@@ -2,19 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+import re
 from pathlib import Path
-from re import Pattern as _re_pattern
-from re import compile as _re_compile
 from typing import Any, Callable, Self
 
 import pydantic
+import yaml
 
 from .datacontract import PydanticModel
 
-_RE_HEADER = _re_compile(r"---\s*([\s\S]*?)\s*---")
-_RE_TOPIC = _re_compile(r"topics:\s*(.*)")
-_RE_URL = _re_compile(r"url:\s*(.*)")
-_RE_BODY = _re_compile(r"---[\s\S]*?---\s*([\s\S]*)")
+_RE_METADATA = re.compile(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", re.DOTALL | re.MULTILINE)
+
+logger = logging.getLogger(__name__)
 
 
 class MarkdownDataContract(PydanticModel):
@@ -45,18 +45,34 @@ class MarkdownDataContract(PydanticModel):
             MarkdownDataContract: The file that was loaded
 
         """
-
-        def find_first(pattern: _re_pattern, text: str, fallback: str):
-            x = pattern.findall(text)
-            return x[0] if len(x) >= 1 else fallback
-
-        def find_header(text: str):
-            match = _RE_HEADER.search(text)
-            return match.group() if match else ""
-
+        # Read MD from file path
         md = path.read_text()
+
+        # Regex to match YAML metadata between --- ... ---
+        metadata = {}
+        metadata_match = _RE_METADATA.match(md)
+        if metadata_match:
+            yaml_str, md_body = metadata_match.groups()
+
+            # Parse YAML string
+            try:
+                metadata = yaml.safe_load(yaml_str)
+            except yaml.YAMLError as e:
+                logger.error(f"Cannot parse YAML metadata in MarkdownDataContract from {path}: {e}", extra={"path": path, "md": md})
+
+            if not isinstance(metadata, dict):
+                logger.error(
+                    f"YAML metadata must be a dictionary in MarkdownDataContract from {path}", extra={"path": path, "metadata": metadata}
+                )
+                metadata = {}  # Overwrite invalid metadata
+        else:
+            # No YAML metadata, whole markdown string as body
+            md_body = md
+            logger.warning(f"MarkdownDataContract has no YAML metadata: {path}", extra={"path": path, "md": md})
+
         return MarkdownDataContract(
-            md=str(find_first(_RE_BODY, md, md)),
-            url=str(find_first(_RE_URL, find_header(md), url_prefix + str(path.absolute()))),
-            keywords=str(find_first(_RE_TOPIC, find_header(md), path.name.split(".")[0])),
+            md=md_body,
+            # Extract metadata fields or use default value
+            url=metadata.get("url", url_prefix + str(path.absolute())),
+            keywords=metadata.get("topics", path.name.split(".")[0]),
         )

--- a/wurzel/datacontract/common.py
+++ b/wurzel/datacontract/common.py
@@ -71,7 +71,7 @@ class MarkdownDataContract(PydanticModel):
         else:
             # No YAML metadata, whole markdown string as body
             md_body = md
-            logger.warning(f"MarkdownDataContract has no YAML metadata: {path}", extra={"path": path, "md": md})
+            logger.info(f"MarkdownDataContract has no YAML metadata: {path}", extra={"path": path, "md": md})
 
         return MarkdownDataContract(
             md=md_body,

--- a/wurzel/datacontract/common.py
+++ b/wurzel/datacontract/common.py
@@ -21,6 +21,31 @@ class MarkdownDataContract(PydanticModel):
     """A data contract of the input of the EmbeddingStep representing a document in Markdown format.
 
     The document consists have the Markdown body (document content) and additional metadata (keywords, url).
+    The metadata is optional.
+
+    Example 1 (with metadata):
+    ```md
+    ---
+    keywords: "bread,butter"
+    url: "some/file/path.md"
+    ---
+    # Some title
+
+    With some more text.
+
+    ## And
+
+    - Other
+    - [Markdown content](#some-link)
+    ```
+
+    Example 2 (without metadata):
+    ```md
+    # Another title
+
+    Another text.
+    ```
+
     """
 
     md: str

--- a/wurzel/datacontract/common.py
+++ b/wurzel/datacontract/common.py
@@ -18,7 +18,10 @@ logger = logging.getLogger(__name__)
 
 
 class MarkdownDataContract(PydanticModel):
-    """contract of the input of the EmbeddingStep."""
+    """A data contract of the input of the EmbeddingStep representing a document in Markdown format.
+
+    The document consists have the Markdown body (document content) and additional metadata (keywords, url).
+    """
 
     md: str
     keywords: str
@@ -36,10 +39,10 @@ class MarkdownDataContract(PydanticModel):
 
     @classmethod
     def from_file(cls, path: Path, url_prefix: str = "") -> Self:
-        """Load MdContract from .md file.
+        """Load MdContract from .md file and parse YAML metadata from header.
 
         Args:
-            path (Path): Path to file
+            path (Path): Path to a Markdown file.
 
         Returns:
             MarkdownDataContract: The file that was loaded


### PR DESCRIPTION

## Description
<!--Please include a summary of the changes and the related issue. Please also include relevant motivation and context.-->

This is a bug fix for #101. It provides a Regex for parsing YAML metadata in Markdown files following the [Jekyll standard](https://jekyllrb.com/docs/front-matter/) (HF etc. use the same).

I also added `PyYAML` as a dependency. In fact, it was already used in the code base without being explicitly added as a direct dependency (it was an indirect dependency). 

## TODOs

- @sam-hey How should the error handling / logging be done?

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run the linter and ensured the code is formatted correctly
- [x] I have updated the documentation accordingly


<!--
Thank you for your contribution! Your efforts help improve the project and are greatly appreciated.-->
