### PR TITLE
fix: Enforcing token minimum on all recursive depths

### DIFF
--- a/tests/splitter_test.py
+++ b/tests/splitter_test.py
@@ -14,7 +14,9 @@ from wurzel.utils.semantic_splitter import (
 
 @pytest.fixture(scope="function")
 def Splitter(env):
-    yield SemanticSplitter()
+    yield SemanticSplitter(
+        token_limit_min=16,  # we use a non-default minimum to have shorter test cases
+    )
 
 
 def test_splitter(Splitter):
@@ -514,3 +516,27 @@ Duis consectetur ex elementum arcu volutpat, vitae rutrum risus vehicula. Donec 
     result = step.run(test_data)
     assert len(result) > 2
     assert isinstance(result[0], MarkdownDataContract)
+
+
+def test_splitter_empty_text(Splitter):
+    contract = MarkdownDataContract(
+        md="",
+        keywords="PurpureusTV Fehlercode F30102",
+        url="https://www.lorem-ipsum.com/aviar/geraete-zubehoer/lorem-tv-geraete/fehlercodes",
+    )
+
+    results = Splitter.split_markdown_document(contract)
+
+    assert len(results) == 0, "Splitter should not return empty docs"
+
+
+def test_splitter_too_short_text(Splitter):
+    contract = MarkdownDataContract(
+        md="This is non empty but too short.",
+        keywords="PurpureusTV Fehlercode F30102",
+        url="https://www.lorem-ipsum.com/aviar/geraete-zubehoer/lorem-tv-geraete/fehlercodes",
+    )
+
+    results = Splitter.split_markdown_document(contract)
+
+    assert len(results) == 0, "Splitter should not return too short docs"

--- a/wurzel/utils/semantic_splitter.py
+++ b/wurzel/utils/semantic_splitter.py
@@ -563,9 +563,8 @@ class SemanticSplitter:
         recursive_depth: int = 1,
     ) -> list[MarkdownDataContract]:
         if self._get_token_len(doc["text"]) <= self.token_limit_min:
-            if recursive_depth == 1:
-                return [self._md_data_from_dict_cut(doc)]
-            log.warning("document to short", extra=doc)
+            # Skipping document since it is below token minium
+            log.warning("document to short", extra={"token_limit_min": self.token_limit_min, **doc})
             return []
         if self._is_within_targetlen_w_buffer(doc["text"]):
             return [self._md_data_from_dict_cut(doc)]


### PR DESCRIPTION
## Description
<!--Please include a summary of the changes and the related issue. Please also include relevant motivation and context.-->

The recursive depth if-clause is removed from the splitter logic, so the minimum token count is actually enforced for all documents.

To not affect existing test cases, the min. token count of the test splitter instance was decreased.

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run the linter and ensured the code is formatted correctly
- <strike>[x] I have updated the documentation accordingly</strike>


<!--
Thank you for your contribution! Your efforts help improve the project and are greatly appreciated.-->
