### PR TITLE
feat: Add support for model_config.env_prefix in SettingsLeaf

### DIFF
--- a/docs/developer-guide/cli.md
+++ b/docs/developer-guide/cli.md
@@ -72,6 +72,8 @@ wurzel inspect wurzel.steps.manual_markdown.ManualMarkdownStep
 wurzel inspect wurzel.steps.manual_markdown.ManualMarkdownStep --gen-env
 ```
 
+The `inspect` command shows the environment variable prefix used by the step. If a step has a custom `env_prefix` defined in its settings, that prefix will be displayed instead of the default step name. The `--gen-env` flag generates the correct environment variable names based on the actual prefix used.
+
 ### Managing Environment Variables
 
 Use the `wurzel env` helper to inspect or validate the variables your pipeline needs:
@@ -94,9 +96,11 @@ wurzel env examples.pipeline.pipelinedemo:pipeline --check --allow-extra-fields
 The `wurzel generate` command creates backend-specific pipeline configurations from chained pipelines.
 
 **Arguments:**
+
 - `pipeline` - Module path to a chained pipeline (multiple steps combined with `>>` operator)
 
 **Options:**
+
 - `-b, --backend` - Backend to use (default: DvcBackend). Case-insensitive.
 - `--list-backends` - List all available backends and exit
 
@@ -138,6 +142,7 @@ pipeline = splitter
 ```
 
 Then generate the pipeline configuration:
+
 ```bash
 wurzel generate myproject.pipelines.pipeline -b DvcBackend
 ```

--- a/docs/developer-guide/creating-steps.md
+++ b/docs/developer-guide/creating-steps.md
@@ -401,9 +401,7 @@ class DeduplicationStep(TypedStep[DeduplicationSettings, list[MarkdownDataContra
         print(f"Deduplication complete: {total_seen} unique documents, {duplicates} duplicates removed")
 ```
 
-## Step Settings and Configuration
-
-<a id="step-settings"></a>
+## Step Settings and Configuration {#step-settings}
 
 ### Environment Variable Integration
 
@@ -453,6 +451,88 @@ class ComplexStepSettings(Settings):
 # PROCESSING__BATCH_SIZE=200
 # DEBUG_MODE=true
 ```
+
+### Custom Environment Variable Prefix
+
+By default, Wurzel uses the step name in uppercase as the environment variable prefix (e.g., `MYSTEP__FIELD_NAME`). You can override this by defining a custom `env_prefix` in your settings class:
+
+```python
+from pydantic_settings import SettingsConfigDict
+from wurzel.step import Settings
+
+class CustomAPISettings(Settings):
+    """API settings with custom environment variable prefix."""
+    model_config = SettingsConfigDict(env_prefix='myapp_api_')
+
+    api_key: str
+    base_url: str = "https://api.example.com"
+    timeout: int = 30
+    max_retries: int = 3
+
+# Environment variables:
+# myapp_api_API_KEY=your_secret_key
+# myapp_api_BASE_URL=https://custom.api.com
+# myapp_api_TIMEOUT=60
+```
+
+#### When to Use Custom Prefixes
+
+Custom prefixes are useful for:
+
+- **Application-wide settings**: Use a consistent prefix across all steps (e.g., `myapp_`)
+- **Shared configuration**: Multiple steps can share the same environment variables
+- **Legacy integration**: Match existing environment variable naming conventions
+- **Environment separation**: Different prefixes for development, staging, and production
+
+#### Priority System
+
+Wurzel follows this priority for environment variable prefixes:
+
+1. **Custom `env_prefix`** from `model_config` (if non-empty)
+2. **Step name uppercase** (default behavior)
+
+#### Example with Multiple Steps
+
+```python
+# Shared settings with custom prefix
+class DatabaseSettings(Settings):
+    model_config = SettingsConfigDict(env_prefix='company_db_')
+
+    host: str = "localhost"
+    port: int = 5432
+    database: str = "app"
+
+class APISettings(Settings):
+    model_config = SettingsConfigDict(env_prefix='company_api_')
+
+    endpoint: str = "https://api.company.com"
+    version: str = "v1"
+
+# Both steps can be used in the same pipeline with different prefixes
+class DataLoaderStep(TypedStep[DatabaseSettings, None, list[DataContract]]):
+    def __init__(self):
+        self.settings = DatabaseSettings()
+        # Reads from: company_db_HOST, company_db_PORT, etc.
+
+class APIProcessorStep(TypedStep[APISettings, list[DataContract], list[DataContract]]):
+    def __init__(self):
+        self.settings = APISettings()
+        # Reads from: company_api_ENDPOINT, company_api_VERSION, etc.
+```
+
+#### Inspecting Environment Variables
+
+You can check which environment variables a step expects using the `wurzel inspect` command:
+
+```bash
+# Show step information including custom env_prefix
+wurzel inspect my_module.MyStep
+
+# Generate environment variable template
+wurzel inspect my_module.MyStep --gen-env
+```
+
+If a step has a custom `env_prefix`, the inspect command will show that prefix instead of the default step name.
 
 ## Testing Custom Steps
 

--- a/tests/settings/test_env_prefix.py
+++ b/tests/settings/test_env_prefix.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG (opensource@telekom.de)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for env_prefix support in SettingsLeaf."""
+
+import os
+
+from pydantic_settings import SettingsConfigDict
+
+from wurzel.step.settings import Settings, SettingsLeaf
+
+
+class CustomPrefixSettings(Settings):
+    """Test settings class with custom env_prefix."""
+
+    model_config = SettingsConfigDict(env_prefix="my_custom_prefix_")
+
+    TEST_FIELD: str = "default_value"
+    ANOTHER_FIELD: int = 42
+
+
+class NestedCustomPrefixSettings(SettingsLeaf):
+    """Test nested settings class with custom env_prefix."""
+
+    model_config = SettingsConfigDict(env_prefix="nested_prefix_")
+
+    NESTED_FIELD: bool = True
+    NESTED_LIST: list[str] = ["default"]
+
+
+def test_custom_env_prefix_direct_usage():
+    """Test that custom env_prefix in model_config is respected when using settings directly."""
+    # Set environment variables with custom prefix
+    os.environ["my_custom_prefix_TEST_FIELD"] = "CUSTOM_VALUE"
+    os.environ["my_custom_prefix_ANOTHER_FIELD"] = "100"  # pragma: allowlist secret
+
+    try:
+        settings = CustomPrefixSettings()
+        assert settings.TEST_FIELD == "CUSTOM_VALUE"
+        assert settings.ANOTHER_FIELD == 100
+    finally:
+        # Clean up
+        del os.environ["my_custom_prefix_TEST_FIELD"]
+        del os.environ["my_custom_prefix_ANOTHER_FIELD"]  # pragma: allowlist secret
+
+
+def test_with_prefix_preserves_existing_config():
+    """Test that with_prefix method preserves existing model_config and only updates env_prefix."""
+    # Test with_prefix method
+    prefixed_class = CustomPrefixSettings.with_prefix("TEST__")
+
+    # Check that the new class has the correct env_prefix
+    assert prefixed_class.model_config["env_prefix"] == "TEST__"
+
+    # Check that other config settings are preserved
+    assert prefixed_class.model_config["extra"] == "forbid"
+    assert prefixed_class.model_config["env_nested_delimiter"] == "__"
+
+    # Test that the prefixed class works with environment variables
+    os.environ["TEST__TEST_FIELD"] = "prefixed_value"
+    try:
+        prefixed_settings = prefixed_class()
+        assert prefixed_settings.TEST_FIELD == "prefixed_value"
+    finally:
+        del os.environ["TEST__TEST_FIELD"]
+
+
+def test_nested_settings_with_custom_prefix():
+    """Test that nested settings with custom env_prefix work correctly."""
+
+    # Create a parent settings class that contains the nested settings
+    class ParentSettings(Settings):
+        NESTED: NestedCustomPrefixSettings
+
+    # Set environment variables for nested settings using the field name prefix
+    # This is the expected behavior for nested settings
+    os.environ["NESTED__NESTED_FIELD"] = "false"
+    os.environ["NESTED__NESTED_LIST"] = '["item1", "item2"]'
+
+    try:
+        parent_settings = ParentSettings()
+
+        # The nested settings should read from the environment
+        assert parent_settings.NESTED.NESTED_FIELD is False
+        assert parent_settings.NESTED.NESTED_LIST == ["item1", "item2"]
+
+    finally:
+        # Clean up
+        del os.environ["NESTED__NESTED_FIELD"]
+        del os.environ["NESTED__NESTED_LIST"]
+
+
+def test_default_env_prefix_fallback():
+    """Test that settings without custom env_prefix still work with step name prefix."""
+
+    class DefaultSettings(Settings):
+        DEFAULT_FIELD: str = "default"
+
+    # Should not have custom env_prefix in model_config or should be empty
+    assert "env_prefix" not in DefaultSettings.model_config or DefaultSettings.model_config["env_prefix"] == ""
+
+    # Test with_prefix still works
+    prefixed = DefaultSettings.with_prefix("DEFAULT__")
+    assert prefixed.model_config["env_prefix"] == "DEFAULT__"
+
+
+def test_empty_env_prefix_fallback():
+    """Test that settings with empty env_prefix fall back to step name prefix."""
+
+    class EmptyPrefixSettings(Settings):
+        model_config = SettingsConfigDict(env_prefix="")
+        TEST_FIELD: str = "test"
+
+    # Should have empty env_prefix in model_config
+    assert EmptyPrefixSettings.model_config["env_prefix"] == ""
+
+    # When used in inspect command, should fall back to step name
+    # This simulates the behavior in cmd_inspect.py
+    if (
+        hasattr(EmptyPrefixSettings, "model_config")
+        and "env_prefix" in EmptyPrefixSettings.model_config
+        and EmptyPrefixSettings.model_config["env_prefix"]
+    ):
+        env_prefix = EmptyPrefixSettings.model_config["env_prefix"]
+    else:
+        env_prefix = "TESTSTEP"  # Simulate step name uppercase
+
+    assert env_prefix == "TESTSTEP"

--- a/tests/settings/test_env_prefix.py
+++ b/tests/settings/test_env_prefix.py
@@ -6,13 +6,21 @@
 
 from pydantic_settings import SettingsConfigDict
 
-from wurzel.step.settings import Settings, SettingsLeaf
+from wurzel.step.settings import Settings, SettingsLeaf, get_env_prefix_from_settings
 
 
 class CustomPrefixSettings(Settings):
     """Test settings class with custom env_prefix."""
 
-    model_config = SettingsConfigDict(env_prefix="my_custom_prefix_")
+    model_config = SettingsConfigDict(
+        env_prefix="my_custom_prefix_",
+        # Preserve all the base SettingsBase configuration
+        env_nested_delimiter="__",
+        extra="forbid",
+        case_sensitive=True,
+        frozen=False,
+        revalidate_instances="always",
+    )
 
     TEST_FIELD: str = "default_value"
     ANOTHER_FIELD: int = 42
@@ -21,13 +29,21 @@ class CustomPrefixSettings(Settings):
 class NestedCustomPrefixSettings(SettingsLeaf):
     """Test nested settings class with custom env_prefix."""
 
-    model_config = SettingsConfigDict(env_prefix="nested_prefix_")
+    model_config = SettingsConfigDict(
+        env_prefix="nested_prefix_",
+        # Preserve all the base SettingsBase configuration
+        env_nested_delimiter="__",
+        extra="forbid",
+        case_sensitive=True,
+        frozen=False,
+        revalidate_instances="always",
+    )
 
     NESTED_FIELD: bool = True
     NESTED_LIST: list[str] = ["default"]
 
 
-def test_windows_case_sensitivity_limitation(monkeypatch):
+def test_windows_case_sensitivity_limitation():
     """Test that documents the Windows case sensitivity limitation.
 
     This test documents the known limitation that on Windows, the case_sensitive=True
@@ -36,48 +52,90 @@ def test_windows_case_sensitivity_limitation(monkeypatch):
 
     See: https://docs.pydantic.dev/latest/concepts/pydantic_settings/#case-sensitivity
     """
-    # Set only one environment variable to avoid conflicts
-    monkeypatch.setenv("my_custom_prefix_TEST_FIELD", "UPPERCASE")
+    # Use direct environment variable setting to avoid monkeypatch issues
+    import os
 
-    settings = CustomPrefixSettings()
-    actual_value = settings.TEST_FIELD
+    original_value = os.environ.get("my_custom_prefix_TEST_FIELD")
 
-    # Should read from the environment variable (not the default value)
-    assert actual_value == "UPPERCASE", (
-        f"Expected UPPERCASE, got '{actual_value}'. Default value 'default_value' suggests environment variables are not being read."
-    )
+    try:
+        # Set environment variable directly - match the exact field name case
+        os.environ["my_custom_prefix_TEST_FIELD"] = "UPPERCASE"
+
+        settings = CustomPrefixSettings()
+        actual_value = settings.TEST_FIELD
+
+        # On Unix-like systems: should read from exact case match
+        # On Windows: case_sensitive is ignored, but should still read from env var
+        assert actual_value == "UPPERCASE", (
+            f"Expected UPPERCASE, got '{actual_value}'. Default value 'default_value' suggests environment variables are not being read."
+        )
+    finally:
+        # Clean up
+        if original_value is None:
+            os.environ.pop("my_custom_prefix_TEST_FIELD", None)
+        else:
+            os.environ["my_custom_prefix_TEST_FIELD"] = original_value
 
 
-def test_case_sensitive_behavior(monkeypatch):
+def test_case_sensitive_behavior():
     """Test that environment variable handling works correctly across platforms."""
-    # Set only one environment variable to avoid conflicts
-    monkeypatch.setenv("my_custom_prefix_TEST_FIELD", "UPPERCASE_VALUE")
+    # Use direct environment variable setting to avoid monkeypatch issues
+    import os
 
-    settings = CustomPrefixSettings()
-    actual_value = settings.TEST_FIELD
+    original_value = os.environ.get("my_custom_prefix_TEST_FIELD")
 
-    # Should read from the environment variable
-    assert actual_value == "UPPERCASE_VALUE", (
-        f"Expected UPPERCASE_VALUE, got '{actual_value}'. This suggests the environment variables are not being read correctly."
-    )
+    try:
+        # Set environment variable directly - match the exact field name case
+        os.environ["my_custom_prefix_TEST_FIELD"] = "UPPERCASE_VALUE"
+
+        settings = CustomPrefixSettings()
+        actual_value = settings.TEST_FIELD
+
+        # Should read from the environment variable
+        assert actual_value == "UPPERCASE_VALUE", (
+            f"Expected UPPERCASE_VALUE, got '{actual_value}'. This suggests the environment variables are not being read correctly."
+        )
+    finally:
+        # Clean up
+        if original_value is None:
+            os.environ.pop("my_custom_prefix_TEST_FIELD", None)
+        else:
+            os.environ["my_custom_prefix_TEST_FIELD"] = original_value
 
 
-def test_custom_env_prefix_direct_usage(monkeypatch):
+def test_custom_env_prefix_direct_usage():
     """Test that custom env_prefix in model_config is respected when using settings directly."""
-    # Set only one environment variable to avoid conflicts
-    monkeypatch.setenv("my_custom_prefix_TEST_FIELD", "CUSTOM_VALUE")
-    monkeypatch.setenv("my_custom_prefix_ANOTHER_FIELD", "100")  # pragma: allowlist secret
+    # Use direct environment variable setting to avoid monkeypatch issues
+    import os
 
-    settings = CustomPrefixSettings()
+    original_test_field = os.environ.get("my_custom_prefix_TEST_FIELD")
+    original_another_field = os.environ.get("my_custom_prefix_ANOTHER_FIELD")
 
-    # Test that the custom prefix works and reads from env vars
-    # On both Windows and Unix-like systems, this should work
-    assert settings.TEST_FIELD == "CUSTOM_VALUE", (
-        f"Expected CUSTOM_VALUE, got '{settings.TEST_FIELD}'. This suggests the custom env_prefix is not working correctly."
-    )
-    assert settings.ANOTHER_FIELD == 100, (
-        f"Expected 100, got {settings.ANOTHER_FIELD}. This suggests the custom env_prefix is not working correctly."
-    )
+    try:
+        # Set environment variables directly - match the exact field name case
+        os.environ["my_custom_prefix_TEST_FIELD"] = "CUSTOM_VALUE"
+        os.environ["my_custom_prefix_ANOTHER_FIELD"] = "100"  # pragma: allowlist secret
+
+        settings = CustomPrefixSettings()
+
+        # Test that the custom prefix works and reads from env vars
+        assert settings.TEST_FIELD == "CUSTOM_VALUE", (
+            f"Expected CUSTOM_VALUE, got '{settings.TEST_FIELD}'. This suggests the custom env_prefix is not working correctly."
+        )
+        assert settings.ANOTHER_FIELD == 100, (
+            f"Expected 100, got {settings.ANOTHER_FIELD}. This suggests the custom env_prefix is not working correctly."
+        )
+    finally:
+        # Clean up
+        if original_test_field is None:
+            os.environ.pop("my_custom_prefix_TEST_FIELD", None)
+        else:
+            os.environ["my_custom_prefix_TEST_FIELD"] = original_test_field
+
+        if original_another_field is None:
+            os.environ.pop("my_custom_prefix_ANOTHER_FIELD", None)  # pragma: allowlist secret
+        else:
+            os.environ["my_custom_prefix_ANOTHER_FIELD"] = original_another_field  # pragma: allowlist secret
 
 
 def test_with_prefix_preserves_existing_config(monkeypatch):
@@ -131,6 +189,107 @@ def test_default_env_prefix_fallback():
     assert prefixed.model_config["env_prefix"] == "DEFAULT__"
 
 
+def test_settings_config_dict_overwrite_behavior():
+    """Test what SettingsConfigDict values get overwritten in different scenarios."""
+
+    # Test 1: Settings class with no custom model_config (should inherit all defaults)
+    class DefaultSettings(Settings):
+        TEST_FIELD: str = "default"
+
+    # Check that it inherits all base configuration
+    assert hasattr(DefaultSettings, "model_config")
+    assert DefaultSettings.model_config.get("env_nested_delimiter") == "__"
+    assert DefaultSettings.model_config.get("extra") == "forbid"
+    assert DefaultSettings.model_config.get("case_sensitive") is True
+    assert DefaultSettings.model_config.get("frozen") is False
+    assert DefaultSettings.model_config.get("revalidate_instances") == "always"
+    # Should not have env_prefix (or should be empty)
+    env_prefix = DefaultSettings.model_config.get("env_prefix", "")
+    assert env_prefix == ""
+
+    # Test 2: Settings class with custom env_prefix only (should preserve other defaults)
+    class CustomPrefixOnlySettings(Settings):
+        model_config = SettingsConfigDict(env_prefix="custom_")
+        TEST_FIELD: str = "default"
+
+    # Should have custom env_prefix but preserve other defaults
+    assert CustomPrefixOnlySettings.model_config.get("env_prefix") == "custom_"
+    assert CustomPrefixOnlySettings.model_config.get("env_nested_delimiter") == "__"
+    assert CustomPrefixOnlySettings.model_config.get("extra") == "forbid"
+    assert CustomPrefixOnlySettings.model_config.get("case_sensitive") is True
+    assert CustomPrefixOnlySettings.model_config.get("frozen") is False
+    assert CustomPrefixOnlySettings.model_config.get("revalidate_instances") == "always"
+
+    # Test 3: Settings class with partial custom config (should override specified, preserve others)
+    class PartialCustomSettings(Settings):
+        model_config = SettingsConfigDict(
+            env_prefix="partial_",
+            extra="allow",  # Override this specific setting
+            frozen=True,  # Override this specific setting
+        )
+        TEST_FIELD: str = "default"
+
+    # Should have custom values for specified settings, preserve defaults for others
+    assert PartialCustomSettings.model_config.get("env_prefix") == "partial_"
+    assert PartialCustomSettings.model_config.get("env_nested_delimiter") == "__"  # Preserved
+    assert PartialCustomSettings.model_config.get("extra") == "allow"  # Overridden
+    assert PartialCustomSettings.model_config.get("case_sensitive") is True  # Preserved
+    assert PartialCustomSettings.model_config.get("frozen") is True  # Overridden
+    assert PartialCustomSettings.model_config.get("revalidate_instances") == "always"  # Preserved
+
+    # Test 4: with_prefix method should preserve all existing config and only change env_prefix
+    prefixed = PartialCustomSettings.with_prefix("with_prefix_")
+
+    # Should have new env_prefix but preserve all other configuration
+    assert prefixed.model_config.get("env_prefix") == "with_prefix_"  # Changed
+    assert prefixed.model_config.get("env_nested_delimiter") == "__"  # Preserved
+    assert prefixed.model_config.get("extra") == "allow"  # Preserved from original
+    assert prefixed.model_config.get("case_sensitive") is True  # Preserved
+    assert prefixed.model_config.get("frozen") is True  # Preserved from original
+    assert prefixed.model_config.get("revalidate_instances") == "always"  # Preserved
+
+
+def test_real_world_step_settings_behavior():
+    """Test the behavior with real step settings like SFTPManualMarkdownStep."""
+    # Import a real step settings class
+    from wurzel.steps.sftp.sftp_manual_markdown import SFTPManualMarkdownSettings
+
+    # Check that it inherits defaults properly
+    assert hasattr(SFTPManualMarkdownSettings, "model_config")
+    assert SFTPManualMarkdownSettings.model_config.get("env_nested_delimiter") == "__"
+    assert SFTPManualMarkdownSettings.model_config.get("extra") == "forbid"
+    assert SFTPManualMarkdownSettings.model_config.get("case_sensitive") is True
+    assert SFTPManualMarkdownSettings.model_config.get("frozen") is False
+    assert SFTPManualMarkdownSettings.model_config.get("revalidate_instances") == "always"
+
+    # Should not have custom env_prefix (should fall back to step name)
+    env_prefix = SFTPManualMarkdownSettings.model_config.get("env_prefix", "")
+    assert env_prefix == ""
+
+    # Test that our utility function works correctly
+    step_env_prefix = get_env_prefix_from_settings(SFTPManualMarkdownSettings, "SFTPManualMarkdownStep")
+    assert step_env_prefix == "SFTPMANUALMARKDOWNSTEP"
+
+
+def test_get_env_prefix_from_settings_utility():
+    """Test the centralized get_env_prefix_from_settings utility function."""
+    # Test with custom env_prefix
+    assert get_env_prefix_from_settings(CustomPrefixSettings, "MyStep") == "my_custom_prefix_"
+
+    # Test with no custom env_prefix (should fall back to step name)
+    class DefaultSettings(Settings):
+        TEST_FIELD: str = "default"
+
+    assert get_env_prefix_from_settings(DefaultSettings, "MyStep") == "MYSTEP"
+
+    # Test with empty env_prefix (should fall back to step name)
+    class EmptyPrefixSettings(Settings):
+        model_config = SettingsConfigDict(env_prefix="")
+        TEST_FIELD: str = "test"
+
+    assert get_env_prefix_from_settings(EmptyPrefixSettings, "TESTSTEP") == "TESTSTEP"
+
+
 def test_empty_env_prefix_fallback():
     """Test that settings with empty env_prefix fall back to step name prefix."""
 
@@ -138,18 +297,6 @@ def test_empty_env_prefix_fallback():
         model_config = SettingsConfigDict(env_prefix="")
         TEST_FIELD: str = "test"
 
-    # Should have empty env_prefix in model_config
-    assert EmptyPrefixSettings.model_config["env_prefix"] == ""
-
-    # When used in inspect command, should fall back to step name
-    # This simulates the behavior in cmd_inspect.py
-    if (
-        hasattr(EmptyPrefixSettings, "model_config")
-        and "env_prefix" in EmptyPrefixSettings.model_config
-        and EmptyPrefixSettings.model_config["env_prefix"]
-    ):
-        env_prefix = EmptyPrefixSettings.model_config["env_prefix"]
-    else:
-        env_prefix = "TESTSTEP"  # Simulate step name uppercase
-
+    # Test the utility function directly
+    env_prefix = get_env_prefix_from_settings(EmptyPrefixSettings, "TESTSTEP")
     assert env_prefix == "TESTSTEP"

--- a/tests/settings/test_env_prefix.py
+++ b/tests/settings/test_env_prefix.py
@@ -251,8 +251,14 @@ def test_settings_config_dict_overwrite_behavior():
 
 def test_real_world_step_settings_behavior():
     """Test the behavior with real step settings like SFTPManualMarkdownStep."""
-    # Import a real step settings class
-    from wurzel.steps.sftp.sftp_manual_markdown import SFTPManualMarkdownSettings
+    # Import a real step settings class (skip if paramiko is not available)
+    try:
+        from wurzel.steps.sftp.sftp_manual_markdown import SFTPManualMarkdownSettings
+    except ImportError:
+        # Skip this test if paramiko is not available
+        import pytest
+
+        pytest.skip("paramiko not available, skipping SFTP step test")
 
     # Check that it inherits defaults properly
     assert hasattr(SFTPManualMarkdownSettings, "model_config")

--- a/tests/settings/test_env_prefix.py
+++ b/tests/settings/test_env_prefix.py
@@ -27,29 +27,76 @@ class NestedCustomPrefixSettings(SettingsLeaf):
     NESTED_LIST: list[str] = ["default"]
 
 
+def test_windows_case_sensitivity_limitation(monkeypatch):
+    """Test that documents the Windows case sensitivity limitation.
+
+    This test documents the known limitation that on Windows, the case_sensitive=True
+    setting in pydantic-settings has no effect because Python's os module treats
+    environment variables as case-insensitive on Windows.
+
+    See: https://docs.pydantic.dev/latest/concepts/pydantic_settings/#case-sensitivity
+    """
+    # Set two environment variables with different cases but same prefix
+    monkeypatch.setenv("my_custom_prefix_TEST_FIELD", "UPPERCASE")
+    monkeypatch.setenv("my_custom_prefix_test_field", "lowercase")
+
+    settings = CustomPrefixSettings()
+
+    # The key insight: on Windows, both variables might be accessible due to OS case insensitivity
+    # On Unix-like systems, only the exact case match should be accessible
+    # This test documents that the behavior differs by platform, which is expected
+    actual_value = settings.TEST_FIELD
+
+    # Should read from one of the environment variables (not the default value)
+    # The specific value depends on the platform and pydantic-settings implementation
+    assert actual_value in ["UPPERCASE", "lowercase"], (
+        f"Expected UPPERCASE or lowercase, got '{actual_value}'. "
+        f"Default value 'default_value' suggests environment variables are not being read."
+    )
+
+
 def test_case_sensitive_behavior(monkeypatch):
-    """Test that environment variable handling is case-sensitive due to case_sensitive=True in model_config."""
-    # Test that case sensitivity is enforced regardless of platform
-    # This should work the same way on Windows and Unix-like systems
+    """Test that environment variable handling works correctly across platforms."""
+    # Test both lowercase and uppercase environment variable names
+    # On Windows, environment variables are case-insensitive at OS level (case_sensitive has no effect)
+    # On Unix-like systems, they are case-sensitive when case_sensitive=True
     monkeypatch.setenv("my_custom_prefix_test_field", "lowercase_value")
     monkeypatch.setenv("my_custom_prefix_TEST_FIELD", "UPPERCASE_VALUE")
 
     settings = CustomPrefixSettings()
-    # Should read from the exact case match, not the lowercase version
-    assert settings.TEST_FIELD == "UPPERCASE_VALUE", f"Expected UPPERCASE_VALUE, got {settings.TEST_FIELD}"
+    actual_value = settings.TEST_FIELD
+
+    # On Unix-like systems with case_sensitive=True: should get UPPERCASE_VALUE (exact match)
+    # On Windows: case_sensitive is ignored, so behavior depends on how pydantic processes the env vars
+    # The important thing is that it reads from one of the environment variables (not the default)
+    assert actual_value in ["lowercase_value", "UPPERCASE_VALUE"], (
+        f"Expected one of ['lowercase_value', 'UPPERCASE_VALUE'], got '{actual_value}'. "
+        "This suggests the environment variables are not being read correctly."
+    )
 
 
 def test_custom_env_prefix_direct_usage(monkeypatch):
     """Test that custom env_prefix in model_config is respected when using settings directly."""
     # Set environment variables with custom prefix
-    # Since case_sensitive=True is set in SettingsBase.model_config,
-    # environment variable names should be case-sensitive across all platforms
+    # Test with both cases to ensure compatibility across platforms
+    # Note: On Windows, case_sensitive is ignored, so we test both cases
     monkeypatch.setenv("my_custom_prefix_TEST_FIELD", "CUSTOM_VALUE")
+    monkeypatch.setenv("my_custom_prefix_test_field", "custom_value_lowercase")
     monkeypatch.setenv("my_custom_prefix_ANOTHER_FIELD", "100")  # pragma: allowlist secret
+    monkeypatch.setenv("my_custom_prefix_another_field", "200")  # pragma: allowlist secret
 
     settings = CustomPrefixSettings()
-    assert settings.TEST_FIELD == "CUSTOM_VALUE", f"Expected CUSTOM_VALUE, got {settings.TEST_FIELD}"
-    assert settings.ANOTHER_FIELD == 100, f"Expected 100, got {settings.ANOTHER_FIELD}"
+
+    # On Unix-like systems with case_sensitive=True: should get exact case matches
+    # On Windows: case_sensitive is ignored, so might get either case
+    # The important thing is that the custom prefix works and reads from env vars
+    assert settings.TEST_FIELD in ["CUSTOM_VALUE", "custom_value_lowercase"], (
+        f"Expected CUSTOM_VALUE or custom_value_lowercase, got '{settings.TEST_FIELD}'. "
+        "This suggests the custom env_prefix is not working correctly."
+    )
+    assert settings.ANOTHER_FIELD in [100, 200], (
+        f"Expected 100 or 200, got {settings.ANOTHER_FIELD}. This suggests the custom env_prefix is not working correctly."
+    )
 
 
 def test_with_prefix_preserves_existing_config(monkeypatch):

--- a/wurzel/cli/cmd_inspect.py
+++ b/wurzel/cli/cmd_inspect.py
@@ -17,26 +17,14 @@ def main(step: "type[TypedStep]", gen_env=False):
     """Execute."""
     # Lazy imports to avoid loading heavy dependencies at import time
     from wurzel.step import Settings  # pylint: disable=import-outside-toplevel
-    from wurzel.step.settings import NoSettings  # pylint: disable=import-outside-toplevel
+    from wurzel.step.settings import NoSettings, get_env_prefix_from_settings  # pylint: disable=import-outside-toplevel
     from wurzel.utils import WZ  # pylint: disable=import-outside-toplevel
 
     ins = WZ(step)
     set_cls: Settings = ins.settings_class
 
-    # Get env_prefix from settings model_config if available and non-empty, otherwise use step name
-    has_custom_prefix = (
-        set_cls != NoneType
-        and set_cls is not None
-        and set_cls != NoSettings
-        and hasattr(set_cls, "model_config")
-        and "env_prefix" in set_cls.model_config
-        and set_cls.model_config["env_prefix"]
-    )
-
-    if has_custom_prefix:
-        env_prefix = set_cls.model_config["env_prefix"]
-    else:
-        env_prefix = step.__name__.upper()
+    # Get env_prefix using the centralized utility function
+    env_prefix = get_env_prefix_from_settings(set_cls, step.__name__)
 
     data = {
         "Name": step.__name__,

--- a/wurzel/cli/cmd_inspect.py
+++ b/wurzel/cli/cmd_inspect.py
@@ -22,7 +22,22 @@ def main(step: "type[TypedStep]", gen_env=False):
 
     ins = WZ(step)
     set_cls: Settings = ins.settings_class
-    env_prefix = step.__name__.upper()
+
+    # Get env_prefix from settings model_config if available and non-empty, otherwise use step name
+    has_custom_prefix = (
+        set_cls != NoneType
+        and set_cls is not None
+        and set_cls != NoSettings
+        and hasattr(set_cls, "model_config")
+        and "env_prefix" in set_cls.model_config
+        and set_cls.model_config["env_prefix"]
+    )
+
+    if has_custom_prefix:
+        env_prefix = set_cls.model_config["env_prefix"]
+    else:
+        env_prefix = step.__name__.upper()
+
     data = {
         "Name": step.__name__,
         "Input": "None" if ins.input_model_class == NoneType else ins.input_model_class,

--- a/wurzel/step/settings.py
+++ b/wurzel/step/settings.py
@@ -122,7 +122,16 @@ class SettingsLeaf(SettingsBase):
     def with_prefix(cls, prefix: str) -> "SettingsLeaf":
         """Returns a new class with env_prefix set."""
         cpy = create_model(prefix + "." + cls.__class__.__name__, __base__=cls)
-        cpy.model_config["env_prefix"] = prefix
+
+        # Get existing model_config or create new one
+        existing_config = getattr(cls, "model_config", SettingsConfigDict())
+
+        # Create new config dict, preserving existing settings and updating env_prefix
+        new_config = dict(existing_config)
+        new_config["env_prefix"] = prefix
+
+        # Set the merged config
+        cpy.model_config = SettingsConfigDict(**new_config)
         return cpy
 
 


### PR DESCRIPTION
## Description
<!--Please include a summary of the changes and the related issue. Please also include relevant motivation and context.-->
Add support for model_config.env_prefix support in SettingsLeaf

```python
class MySettings(Settings):
    model_config = SettingsConfigDict(env_prefix='original_')
    API_URL: str = "default"
```

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run the linter and ensured the code is formatted correctly
- [ ] I have updated the documentation accordingly


<!--
Thank you for your contribution! Your efforts help improve the project and are greatly appreciated.-->
