### PR TITLE
feat: add support for configurable step executors in Argo backend

### DIFF
--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -37,6 +37,7 @@ def setup_argo_test_env():
         "ARGO_SERVER",
         "ARGO_TOKEN",
         "KUBECONFIG",
+        "PROMETHEUS_GATEWAY",
     ]
 
     for var in env_vars_to_clear:

--- a/tests/backend/test_backend_argo.py
+++ b/tests/backend/test_backend_argo.py
@@ -29,6 +29,7 @@ from wurzel.backend.backend_argo import (
     select_workflow,
 )
 from wurzel.backend.values import ValuesFileError, deep_merge_dicts, load_values
+from wurzel.step_executor import BaseStepExecutor, PrometheusStepExecutor
 
 from .conftest import DummyFollowStep, DummyStep
 
@@ -858,6 +859,49 @@ class TestArgoBackendCreateArtifactFromStep:
         artifact2 = backend._create_artifact_from_step(step)
 
         assert artifact1 is artifact2  # Same object due to @cache
+
+
+class TestArgoBackendGeneratedCliExecutor:
+    """Generated Argo container commands must pass ``-e`` for the chosen step executor."""
+
+    @staticmethod
+    def _first_wurzel_command(workflow: dict) -> str:
+        spec = workflow.get("spec", {})
+        if "workflowSpec" in spec:
+            templates = spec["workflowSpec"].get("templates", [])
+        else:
+            templates = spec.get("templates", [])
+        for template in templates:
+            cmd = template.get("container", {}).get("command")
+            if cmd and any("wurzel" in part for part in cmd):
+                return " ".join(cmd)
+        raise AssertionError("no wurzel container command found")
+
+    def test_default_uses_base_executor_without_prometheus_gateway(self):
+        backend = ArgoBackend()
+        yaml_output = backend.generate_artifact(DummyStep())
+        cmd = self._first_wurzel_command(yaml.safe_load(yaml_output))
+        assert "-e BaseStepExecutor" in cmd
+
+    def test_uses_prometheus_executor_when_prometheus_gateway_set(self, monkeypatch):
+        monkeypatch.setenv("PROMETHEUS_GATEWAY", "pushgateway.example:9091")
+        backend = ArgoBackend()
+        yaml_output = backend.generate_artifact(DummyStep())
+        cmd = self._first_wurzel_command(yaml.safe_load(yaml_output))
+        assert "-e PrometheusStepExecutor" in cmd
+
+    def test_explicit_executor_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("PROMETHEUS_GATEWAY", "pushgateway.example:9091")
+        backend = ArgoBackend(executor=BaseStepExecutor)
+        yaml_output = backend.generate_artifact(DummyStep())
+        cmd = self._first_wurzel_command(yaml.safe_load(yaml_output))
+        assert "-e BaseStepExecutor" in cmd
+
+    def test_explicit_prometheus_without_env(self):
+        backend = ArgoBackend(executor=PrometheusStepExecutor)
+        yaml_output = backend.generate_artifact(DummyStep())
+        cmd = self._first_wurzel_command(yaml.safe_load(yaml_output))
+        assert "-e PrometheusStepExecutor" in cmd
 
 
 class TestArgoBackendCreateTask:

--- a/tests/backend/test_backend_argo.py
+++ b/tests/backend/test_backend_argo.py
@@ -903,6 +903,21 @@ class TestArgoBackendGeneratedCliExecutor:
         cmd = self._first_wurzel_command(yaml.safe_load(yaml_output))
         assert "-e PrometheusStepExecutor" in cmd
 
+    def test_uses_prometheus_executor_when_set_in_container_env(self):
+        config = WorkflowConfig(container=ContainerConfig(env={"PROMETHEUS_GATEWAY": "pushgateway.example:9091"}))
+        backend = ArgoBackend(config=config)
+        yaml_output = backend.generate_artifact(DummyStep())
+        cmd = self._first_wurzel_command(yaml.safe_load(yaml_output))
+        assert "-e PrometheusStepExecutor" in cmd
+
+    def test_container_env_takes_precedence_over_os_environ(self, monkeypatch):
+        monkeypatch.delenv("PROMETHEUS_GATEWAY", raising=False)
+        config = WorkflowConfig(container=ContainerConfig(env={"PROMETHEUS_GATEWAY": "pushgateway.example:9091"}))
+        backend = ArgoBackend(config=config)
+        yaml_output = backend.generate_artifact(DummyStep())
+        cmd = self._first_wurzel_command(yaml.safe_load(yaml_output))
+        assert "-e PrometheusStepExecutor" in cmd
+
 
 class TestArgoBackendCreateTask:
     def test_task_creation(self):

--- a/tests/cli/test_cmd_generate.py
+++ b/tests/cli/test_cmd_generate.py
@@ -29,9 +29,10 @@ def test_resolve_backend_instance_uses_from_values_for_argo(monkeypatch, tmp_pat
     sentinel = object()
     captured: dict[str, object] = {}
 
-    def fake_from_values(cls, files, workflow_name=None):  # noqa: ANN001
+    def fake_from_values(cls, files, workflow_name=None, *, executor=None):  # noqa: ANN001
         captured["files"] = files
         captured["workflow"] = workflow_name
+        captured["executor"] = executor
         return sentinel
 
     monkeypatch.setattr(ArgoBackend, "from_values", classmethod(fake_from_values))
@@ -41,6 +42,7 @@ def test_resolve_backend_instance_uses_from_values_for_argo(monkeypatch, tmp_pat
     assert adapter is sentinel
     assert captured["files"] == [values_file]
     assert captured["workflow"] == "demo"
+    assert captured["executor"] is None
 
 
 @pytest.mark.skipif(not HAS_HERA, reason="Argo backend requires Hera extras")
@@ -56,6 +58,30 @@ def test_resolve_backend_instance_inits_argo_without_values(monkeypatch):
 
     assert isinstance(adapter, ArgoBackend)
     assert init_calls == [((), {})]
+
+
+@pytest.mark.skipif(not HAS_HERA, reason="Argo backend requires Hera extras")
+def test_resolve_backend_instance_passes_executor_to_argo_from_values(monkeypatch, tmp_path):
+    from wurzel.step_executor import PrometheusStepExecutor
+
+    values_file = tmp_path / "values.yaml"
+    values_file.write_text("workflows: {}")
+    captured: dict[str, object] = {}
+
+    def fake_from_values(cls, files, workflow_name=None, *, executor=None):  # noqa: ANN001
+        captured["executor"] = executor
+        return object()
+
+    monkeypatch.setattr(ArgoBackend, "from_values", classmethod(fake_from_values))
+
+    cmd_generate._resolve_backend_instance(
+        ArgoBackend,
+        [values_file],
+        "demo",
+        executor=PrometheusStepExecutor,
+    )
+
+    assert captured["executor"] is PrometheusStepExecutor
 
 
 def test_resolve_backend_instance_for_non_argo_backend(tmp_path):
@@ -87,10 +113,11 @@ def test_cmd_generate_main_resolves_backend_with_iterable_values(monkeypatch, tm
 
     captured: dict[str, object] = {}
 
-    def fake_resolve(backend, values, pipeline_name):  # noqa: ANN001, ANN002, ANN003
+    def fake_resolve(backend, values, pipeline_name, executor=None):  # noqa: ANN001, ANN002, ANN003
         captured["backend"] = backend
         captured["values"] = values
         captured["pipeline_name"] = pipeline_name
+        captured["executor"] = executor
         return Adapter()
 
     monkeypatch.setattr(cmd_generate, "_resolve_backend_instance", fake_resolve)
@@ -102,6 +129,7 @@ def test_cmd_generate_main_resolves_backend_with_iterable_values(monkeypatch, tm
     assert captured["backend"] is _MinimalBackend
     assert captured["values"] == [values_file]
     assert captured["pipeline_name"] == "wf-name"
+    assert captured["executor"] is None
 
 
 def test_cmd_generate_main_writes_to_output(monkeypatch, tmp_path):
@@ -109,10 +137,11 @@ def test_cmd_generate_main_writes_to_output(monkeypatch, tmp_path):
         def generate_artifact(self, step):  # noqa: ARG002
             return "artifact-yaml"
 
-    def fake_resolve(backend, values, pipeline_name):  # noqa: ANN001, ANN002, ANN003
+    def fake_resolve(backend, values, pipeline_name, executor=None):  # noqa: ANN001, ANN002, ANN003
         assert backend is _MinimalBackend
         assert values == []
         assert pipeline_name is None
+        assert executor is None
         return Adapter()
 
     monkeypatch.setattr(cmd_generate, "_resolve_backend_instance", fake_resolve)

--- a/wurzel/backend/backend_argo.py
+++ b/wurzel/backend/backend_argo.py
@@ -48,13 +48,16 @@ from wurzel.step_executor import BaseStepExecutor, PrometheusStepExecutor
 log = logging.getLogger(__name__)
 
 
-def default_argo_step_executor() -> type[BaseStepExecutor]:
+def default_argo_step_executor(config: "WorkflowConfig | None" = None) -> type[BaseStepExecutor]:
     """Pick the step executor for generated Argo task commands.
 
-    When ``PROMETHEUS_GATEWAY`` is set (non-empty), emitted ``wurzel run`` lines
-    use ``PrometheusStepExecutor`` so metrics match runtime pushgateway config.
-    Otherwise ``BaseStepExecutor`` is used.
+    When ``PROMETHEUS_GATEWAY`` is set (non-empty) in the workflow container
+    env (preferred) or in the generator process environment (fallback), emitted
+    ``wurzel run`` lines use ``PrometheusStepExecutor`` so metrics match the
+    runtime pushgateway config.  Otherwise ``BaseStepExecutor`` is used.
     """
+    if config is not None and config.container.env.get("PROMETHEUS_GATEWAY", "").strip():
+        return PrometheusStepExecutor
     if os.environ.get("PROMETHEUS_GATEWAY", "").strip():
         return PrometheusStepExecutor
     return BaseStepExecutor
@@ -212,9 +215,9 @@ class ArgoBackend(Backend):
         executor: type[BaseStepExecutor] | None = None,
     ) -> None:
         super().__init__()
-        self.executor: type[BaseStepExecutor] = executor if executor is not None else default_argo_step_executor()
         self.values = values or TemplateValues()
         self.config = config or select_workflow(self.values, workflow_name)
+        self.executor: type[BaseStepExecutor] = executor if executor is not None else default_argo_step_executor(self.config)
         self._volumes, self._volume_mounts = self._build_volumes()
 
     @classmethod

--- a/wurzel/backend/backend_argo.py
+++ b/wurzel/backend/backend_argo.py
@@ -48,7 +48,7 @@ from wurzel.step_executor import BaseStepExecutor, PrometheusStepExecutor
 log = logging.getLogger(__name__)
 
 
-def default_argo_step_executor(config: "WorkflowConfig | None" = None) -> type[BaseStepExecutor]:
+def default_argo_step_executor(config: WorkflowConfig | None = None) -> type[BaseStepExecutor]:
     """Pick the step executor for generated Argo task commands.
 
     When ``PROMETHEUS_GATEWAY`` is set (non-empty) in the workflow container

--- a/wurzel/backend/backend_argo.py
+++ b/wurzel/backend/backend_argo.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Iterable
 from functools import cache
 from pathlib import Path
@@ -45,6 +46,18 @@ from wurzel.step import TypedStep
 from wurzel.step_executor import BaseStepExecutor, PrometheusStepExecutor
 
 log = logging.getLogger(__name__)
+
+
+def default_argo_step_executor() -> type[BaseStepExecutor]:
+    """Pick the step executor for generated Argo task commands.
+
+    When ``PROMETHEUS_GATEWAY`` is set (non-empty), emitted ``wurzel run`` lines
+    use ``PrometheusStepExecutor`` so metrics match runtime pushgateway config.
+    Otherwise ``BaseStepExecutor`` is used.
+    """
+    if os.environ.get("PROMETHEUS_GATEWAY", "").strip():
+        return PrometheusStepExecutor
+    return BaseStepExecutor
 
 
 # ---------------------------------------------------------------------------
@@ -196,19 +209,25 @@ class ArgoBackend(Backend):
         *,
         values: TemplateValues | None = None,
         workflow_name: str | None = None,
-        executor: type[BaseStepExecutor] = PrometheusStepExecutor,
+        executor: type[BaseStepExecutor] | None = None,
     ) -> None:
         super().__init__()
-        self.executor: type[BaseStepExecutor] = executor
+        self.executor: type[BaseStepExecutor] = executor if executor is not None else default_argo_step_executor()
         self.values = values or TemplateValues()
         self.config = config or select_workflow(self.values, workflow_name)
         self._volumes, self._volume_mounts = self._build_volumes()
 
     @classmethod
-    def from_values(cls, files: Iterable[Path], workflow_name: str | None = None) -> ArgoBackend:
+    def from_values(
+        cls,
+        files: Iterable[Path],
+        workflow_name: str | None = None,
+        *,
+        executor: type[BaseStepExecutor] | None = None,
+    ) -> ArgoBackend:
         """Instantiate the backend from values files."""
         values = load_values(files, TemplateValues)
-        return cls(values=values, workflow_name=workflow_name)
+        return cls(values=values, workflow_name=workflow_name, executor=executor)
 
     # ------------------------------------------------------------------ helpers
     def _build_volumes(self) -> tuple[list[SecretVolume | ExistingVolume | Volume], list[VolumeMount]]:
@@ -444,6 +463,7 @@ class ArgoBackend(Backend):
             step.__class__,
             inputs=[Path(inpt.path) for inpt in inputs if inpt.path],
             output=self.config.dataDir / step.__class__.__name__,
+            executor=self.executor,
         )
         commands: list[str] = [entry for entry in cli_call.split(" ") if entry.strip()]
 

--- a/wurzel/backend/backend_dvc.py
+++ b/wurzel/backend/backend_dvc.py
@@ -116,10 +116,18 @@ class DvcBackend(Backend):
         )
 
     @classmethod
-    def from_values(cls, files: Iterable[Path], workflow_name: str | None = None) -> "DvcBackend":
+    def from_values(
+        cls,
+        files: Iterable[Path],
+        workflow_name: str | None = None,
+        *,
+        executor: type[BaseStepExecutor] | None = None,
+    ) -> "DvcBackend":
         """Instantiate the backend from values files."""
         values = load_values(files, DvcTemplateValues)
         config = select_pipeline(values, workflow_name)
+        if executor is not None:
+            return cls(config=config, executor=executor)
         return cls(config=config)
 
     def _generate_dict(

--- a/wurzel/cli/_main.py
+++ b/wurzel/cli/_main.py
@@ -32,23 +32,25 @@ if TYPE_CHECKING:  # pragma: no cover - only for typing
     from wurzel.step import TypedStep
 
 
-def executer_callback(_ctx: typer.Context, _param: typer.CallbackParam, value: str):
+def executer_callback(_ctx: typer.Context, _param: typer.CallbackParam, value: str | None):
     """Convert a cli-str to a Type[BaseStepExecutor].
 
     Args:
         _ctx (typer.Context)
         _param (typer.CallbackParam):
-        value (str): user typed string
+        value (str | None): user typed string, or None when option is omitted
 
     Raises:
         typer.BadParameter: If user typed string does not correlate with a Executor
 
     Returns:
-        Type[BaseStepExecutor]: {BaseStepExecutor, PrometheusStepExecutor}
+        Type[BaseStepExecutor] | None: {BaseStepExecutor, PrometheusStepExecutor, None}
 
     """
     from wurzel.step_executor import BaseStepExecutor, PrometheusStepExecutor  # pylint: disable=import-outside-toplevel
 
+    if value is None:
+        return None
     if "BASESTEPEXECUTOR".startswith(value.upper()):
         return BaseStepExecutor
     if "PROMETHEUSSTEPEXECUTOR".startswith(value.upper()):
@@ -583,6 +585,7 @@ def generate(  # pylint: disable=too-many-positional-arguments
             "-e",
             "--executor",
             help="Step executor class for generated commands (overrides defaults and PROMETHEUS_GATEWAY for Argo)",
+            callback=executer_callback,
             autocompletion=lambda: ["BaseStepExecutor", "PrometheusStepExecutor"],
         ),
     ] = None,
@@ -625,7 +628,6 @@ def generate(  # pylint: disable=too-many-positional-arguments
     from wurzel.backend.values import ValuesFileError  # pylint: disable=import-outside-toplevel
     from wurzel.cli.cmd_generate import main as cmd_generate  # pylint: disable=import-outside-toplevel
 
-    executor_cls = executer_callback(None, None, executor) if executor else None
     log.debug(
         "generate pipeline",
         extra={
@@ -635,7 +637,7 @@ def generate(  # pylint: disable=too-many-positional-arguments
                 "values": values,
                 "pipeline_name": pipeline_name,
                 "output": output,
-                "executor": executor_cls,
+                "executor": executor,
             }
         },
     )
@@ -646,7 +648,7 @@ def generate(  # pylint: disable=too-many-positional-arguments
             values=values or [],
             pipeline_name=pipeline_name,
             output=output,
-            executor=executor_cls,
+            executor=executor,
         )
     except ValuesFileError as exc:
         raise typer.BadParameter(str(exc)) from exc

--- a/wurzel/cli/_main.py
+++ b/wurzel/cli/_main.py
@@ -577,6 +577,15 @@ def generate(  # pylint: disable=too-many-positional-arguments
         str | None,
         typer.Option("--pipeline-name", help="pipeline name to render from the provided values files"),
     ] = None,
+    executor: Annotated[
+        str | None,
+        typer.Option(
+            "-e",
+            "--executor",
+            help="Step executor class for generated commands (overrides defaults and PROMETHEUS_GATEWAY for Argo)",
+            autocompletion=lambda: ["BaseStepExecutor", "PrometheusStepExecutor"],
+        ),
+    ] = None,
     output: Annotated[
         Path | None,
         typer.Option(
@@ -616,6 +625,7 @@ def generate(  # pylint: disable=too-many-positional-arguments
     from wurzel.backend.values import ValuesFileError  # pylint: disable=import-outside-toplevel
     from wurzel.cli.cmd_generate import main as cmd_generate  # pylint: disable=import-outside-toplevel
 
+    executor_cls = executer_callback(None, None, executor) if executor else None
     log.debug(
         "generate pipeline",
         extra={
@@ -625,6 +635,7 @@ def generate(  # pylint: disable=too-many-positional-arguments
                 "values": values,
                 "pipeline_name": pipeline_name,
                 "output": output,
+                "executor": executor_cls,
             }
         },
     )
@@ -635,6 +646,7 @@ def generate(  # pylint: disable=too-many-positional-arguments
             values=values or [],
             pipeline_name=pipeline_name,
             output=output,
+            executor=executor_cls,
         )
     except ValuesFileError as exc:
         raise typer.BadParameter(str(exc)) from exc

--- a/wurzel/cli/cmd_generate.py
+++ b/wurzel/cli/cmd_generate.py
@@ -11,16 +11,20 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from wurzel.backend.backend import Backend
     from wurzel.step.typed_step import TypedStep
+    from wurzel.step_executor import BaseStepExecutor
 
 
 def _resolve_backend_instance(
     backend: type[Backend],
     values: list[Path] | None,
     pipeline_name: str | None,
+    executor: type[BaseStepExecutor] | None = None,
 ) -> Backend:
     # Check if backend has from_values method (like ArgoBackend and DvcBackend)
     if hasattr(backend, "from_values") and values:
-        return backend.from_values(values, workflow_name=pipeline_name)  # type: ignore[call-arg]
+        return backend.from_values(values, workflow_name=pipeline_name, executor=executor)  # type: ignore[call-arg]
+    if executor is not None:
+        return backend(executor=executor)  # type: ignore[call-arg]
     return backend()
 
 
@@ -36,9 +40,10 @@ def main(
     values: Iterable[Path] | None = None,
     pipeline_name: str | None = None,
     output: Path | None = None,
+    executor: type[BaseStepExecutor] | None = None,
 ) -> str:
     """Generate backend-specific YAML for a pipeline."""
-    adapter = _resolve_backend_instance(backend, list(values or []), pipeline_name)
+    adapter = _resolve_backend_instance(backend, list(values or []), pipeline_name, executor)
     yaml_content = adapter.generate_artifact(step)
 
     if output:


### PR DESCRIPTION
- Introduced `PROMETHEUS_GATEWAY` environment variable to determine the step executor.
- Updated `ArgoBackend` to accept an optional executor parameter in `from_values` and constructor.
- Enhanced CLI to allow specifying the executor via command line.
- Added tests to verify executor selection logic based on environment variable and explicit settings.

## Description
<!--Please include a summary of the changes and the related issue. Please also include relevant motivation and context.-->


## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run the linter and ensured the code is formatted correctly
- [x] I have updated the documentation accordingly


<!--
Thank you for your contribution! Your efforts help improve the project and are greatly appreciated.-->
