### PR TITLE
feat(wonderful): exclude private documents from KB upload

### DIFF
--- a/tests/steps/wonderful/step_test.py
+++ b/tests/steps/wonderful/step_test.py
@@ -336,19 +336,25 @@ class TestPerWorkerSession:
 
 
 class TestNeverejnyFilter:
-    def test_doc_with_neverejny_in_url_is_excluded(self, step, requests_mock):
+    def test_neverejny_doc_is_not_uploaded(self, step, requests_mock):
         doc = MarkdownDataContract(md="# Secret", url="https://example.com/docs/nabidka_neverejny.md", keywords="")
         result = step.run([doc])
-        assert result == []
+        assert result == [doc]  # passthrough unchanged
         assert requests_mock.request_history == []
 
-    def test_doc_with_neverejna_in_url_is_excluded(self, step, requests_mock):
+    def test_neverejna_doc_is_not_uploaded(self, step, requests_mock):
         doc = MarkdownDataContract(md="# Secret", url="https://example.com/docs/nabidka_neverejna.md", keywords="")
         result = step.run([doc])
-        assert result == []
+        assert result == [doc]  # passthrough unchanged
         assert requests_mock.request_history == []
 
-    def test_only_clean_doc_is_uploaded_and_returned(self, step, requests_mock):
+    def test_neverejny_is_case_insensitive(self, step, requests_mock):
+        doc = MarkdownDataContract(md="# Secret", url="https://example.com/docs/nabidka_NEVEREJNY.md", keywords="")
+        result = step.run([doc])
+        assert result == [doc]  # passthrough unchanged
+        assert requests_mock.request_history == []
+
+    def test_only_clean_doc_is_uploaded_full_input_returned(self, step, requests_mock):
         clean = MarkdownDataContract(md="# Public", url="https://example.com/docs/nabidka_verejny.md", keywords="")
         secret = MarkdownDataContract(md="# Secret", url="https://example.com/docs/nabidka_neverejny.md", keywords="")
         requests_mock.get(KB_FILES, json=kb_list_payload())
@@ -358,15 +364,15 @@ class TestNeverejnyFilter:
 
         result = step.run([clean, secret])
 
-        assert result == [clean]
+        assert result == [clean, secret]  # full input returned as passthrough
         assert requests_mock.request_history[0].method == "GET"
         assert sum(1 for r in requests_mock.request_history if r.method == "POST") == 2  # create + sync
 
-    def test_all_neverejny_returns_empty_without_api_calls(self, step, requests_mock):
+    def test_all_neverejny_skips_upload_passes_through(self, step, requests_mock):
         docs = [
             MarkdownDataContract(md="# A", url="https://example.com/docs/nabidka_neverejny.md", keywords=""),
             MarkdownDataContract(md="# B", url="https://example.com/docs/prehled_neverejny.md", keywords=""),
         ]
         result = step.run(docs)
-        assert result == []
+        assert result == docs  # passthrough unchanged
         assert requests_mock.request_history == []

--- a/tests/steps/wonderful/step_test.py
+++ b/tests/steps/wonderful/step_test.py
@@ -330,3 +330,43 @@ class TestPerWorkerSession:
 
         # 1× main thread (existing-files fetch) + 2× workers (one per doc).
         assert spy.call_count == 3
+
+
+# ── Neverejny filter ──────────────────────────────────────────────────────────
+
+
+class TestNeverejnyFilter:
+    def test_doc_with_neverejny_in_url_is_excluded(self, step, requests_mock):
+        doc = MarkdownDataContract(md="# Secret", url="https://example.com/docs/nabidka_neverejny.md", keywords="")
+        result = step.run([doc])
+        assert result == []
+        assert requests_mock.request_history == []
+
+    def test_doc_with_neverejna_in_url_is_excluded(self, step, requests_mock):
+        doc = MarkdownDataContract(md="# Secret", url="https://example.com/docs/nabidka_neverejna.md", keywords="")
+        result = step.run([doc])
+        assert result == []
+        assert requests_mock.request_history == []
+
+    def test_only_clean_doc_is_uploaded_and_returned(self, step, requests_mock):
+        clean = MarkdownDataContract(md="# Public", url="https://example.com/docs/nabidka_verejny.md", keywords="")
+        secret = MarkdownDataContract(md="# Secret", url="https://example.com/docs/nabidka_neverejny.md", keywords="")
+        requests_mock.get(KB_FILES, json=kb_list_payload())
+        requests_mock.post(KB_FILES, json=kb_create_payload("file-1"))
+        requests_mock.put(PRESIGNED)
+        requests_mock.post(KB_SYNC, json={})
+
+        result = step.run([clean, secret])
+
+        assert result == [clean]
+        assert requests_mock.request_history[0].method == "GET"
+        assert sum(1 for r in requests_mock.request_history if r.method == "POST") == 2  # create + sync
+
+    def test_all_neverejny_returns_empty_without_api_calls(self, step, requests_mock):
+        docs = [
+            MarkdownDataContract(md="# A", url="https://example.com/docs/nabidka_neverejny.md", keywords=""),
+            MarkdownDataContract(md="# B", url="https://example.com/docs/prehled_neverejny.md", keywords=""),
+        ]
+        result = step.run(docs)
+        assert result == []
+        assert requests_mock.request_history == []

--- a/wurzel/steps/wonderful/step.py
+++ b/wurzel/steps/wonderful/step.py
@@ -180,6 +180,12 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
         if self.settings.SKIP:
             log.info(f"WonderfulRAGStep skipped — passing through {len(inpt)} documents unchanged")
             return inpt
+        # "neverejn" matches both Czech genders: neverejny (masc.) and neverejna (fem.)
+        filtered = [doc for doc in inpt if "neverejn" not in doc.url]
+        if len(filtered) < len(inpt):
+            log.info(f"Excluded {len(inpt) - len(filtered)} document(s) with 'neverejn' in filename")
+        inpt = filtered
+
         if not inpt:
             log.warning("No documents to process")
             return []

--- a/wurzel/steps/wonderful/step.py
+++ b/wurzel/steps/wonderful/step.py
@@ -180,25 +180,28 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
         if self.settings.SKIP:
             log.info(f"WonderfulRAGStep skipped — passing through {len(inpt)} documents unchanged")
             return inpt
-        # "neverejn" matches both Czech genders: neverejny (masc.) and neverejna (fem.)
-        filtered = [doc for doc in inpt if "neverejn" not in doc.url]
-        if len(filtered) < len(inpt):
-            log.info(f"Excluded {len(inpt) - len(filtered)} document(s) with 'neverejn' in filename")
-        inpt = filtered
-
         if not inpt:
             log.warning("No documents to process")
             return []
+
+        # "neverejn" matches both Czech genders: neverejny (masc.) and neverejna (fem.)
+        # .casefold() ensures case-insensitive matching (e.g. Neverejny, NEVEREJNY).
+        to_upload = [doc for doc in inpt if "neverejn" not in doc.url.casefold()]
+        excluded = len(inpt) - len(to_upload)
+        if excluded:
+            log.info(f"Excluded {excluded} document(s) with 'neverejn' in URL")
+        if not to_upload:
+            return inpt
 
         # Pre-dedup by generated filename so two input docs with the same KB
         # filename don't race in the worker pool and create duplicate KB records.
         # When two docs map to the same filename, the later occurrence wins.
         unique: dict[str, tuple[int, MarkdownDataContract]] = {}
-        for idx, doc in enumerate(inpt):
+        for idx, doc in enumerate(to_upload):
             unique[self._generate_filename(doc, idx)] = (idx, doc)
         deduped = list(unique.values())
-        if len(deduped) < len(inpt):
-            log.info(f"Deduped input: {len(inpt)} → {len(deduped)} unique filenames")
+        if len(deduped) < len(to_upload):
+            log.info(f"Deduped input: {len(to_upload)} → {len(deduped)} unique filenames")
 
         log.info(f"Uploading {len(deduped)} documents to Wonderful KB {self._kb_id}")
         with self._build_session() as session:


### PR DESCRIPTION
## Summary

- Adds a filter in `WonderfulRAGStep.run()` that excludes documents whose URL contains `neverejn` before uploading to the Wonderful RAG knowledge base
- Matches both Czech grammatical genders: *neverejny* (masculine) and *neverejna* (feminine)
- Excluded documents are logged and dropped from the passthrough return value

## Test plan

- [x] `uv run pytest tests/steps/wonderful/step_test.py::TestNeverejnyFilter -v`
- [x] Verify masculine form (`nabidka_neverejny.md`) is excluded
- [x] Verify feminine form (`nabidka_neverejna.md`) is excluded
- [x] Verify clean documents are unaffected
- [x] Verify all-private input returns empty without any API calls