### PR TITLE
fix(wonderful): align connector with live API — retries, fire-and-forget sync, optional prune

### DIFF
--- a/tests/steps/wonderful/step_test.py
+++ b/tests/steps/wonderful/step_test.py
@@ -510,3 +510,68 @@ class TestRetry:
 
         assert delete_mock.called  # orphan record rolled back
         assert delete_mock.last_request.json() == {"file_ids": [file_id]}  # by id, in the body
+
+
+# ── Prune (mirror KB to input) ──────────────────────────────────────────────────
+
+
+class TestPrune:
+    """PRUNE_STALE deletes files in the KB that are absent from the input, before sync.
+    Gated (off by default) and skipped on any upload failure.
+    """
+
+    @pytest.fixture
+    def prune_step(self, wonderful_env):
+        wonderful_env.set("PRUNE_STALE", "true")
+        s = WonderfulRAGStep()
+        yield s
+        s.finalize()
+
+    KEEP = MarkdownDataContract(md="# Keep", url="https://example.com/docs/keep", keywords="")
+    # KEEP maps to filename "docs/keep.md"
+
+    def test_prune_disabled_by_default(self, step, requests_mock):
+        requests_mock.get(KB_FILES, json=kb_list_payload(("docs/keep.md", "id-keep"), ("docs/stale.md", "id-stale")))
+        requests_mock.post(STORAGE_UPLOAD, json={})  # keep already exists → update path
+        requests_mock.post(KB_SYNC, json={})
+        delete_mock = requests_mock.delete(KB_FILES, json={})
+
+        assert step.run([self.KEEP]) == [self.KEEP]
+        assert not delete_mock.called  # no prune unless PRUNE_STALE=true
+
+    def test_prune_deletes_stale_before_sync(self, prune_step, requests_mock):
+        requests_mock.get(KB_FILES, json=kb_list_payload(("docs/keep.md", "id-keep"), ("docs/stale.md", "id-stale")))
+        requests_mock.post(STORAGE_UPLOAD, json={})
+        requests_mock.post(KB_SYNC, json={})
+        delete_mock = requests_mock.delete(KB_FILES, json={})
+
+        assert prune_step.run([self.KEEP]) == [self.KEEP]
+
+        assert delete_mock.called
+        assert delete_mock.last_request.json() == {"file_ids": ["id-stale"]}  # only the stale one
+        # Prune must happen before the sync re-index.
+        order = [(r.method, r.url) for r in requests_mock.request_history]
+        delete_idx = next(i for i, (m, _) in enumerate(order) if m == "DELETE")
+        sync_idx = next(i for i, (m, u) in enumerate(order) if m == "POST" and u.startswith(KB_SYNC))
+        assert delete_idx < sync_idx
+
+    def test_prune_noop_when_kb_matches_input(self, prune_step, requests_mock):
+        requests_mock.get(KB_FILES, json=kb_list_payload(("docs/keep.md", "id-keep")))  # KB == input
+        requests_mock.post(STORAGE_UPLOAD, json={})
+        requests_mock.post(KB_SYNC, json={})
+        delete_mock = requests_mock.delete(KB_FILES, json={})
+
+        assert prune_step.run([self.KEEP]) == [self.KEEP]
+        assert not delete_mock.called  # nothing stale to delete
+
+    def test_prune_skipped_on_upload_failure(self, prune_step, requests_mock):
+        new_doc = MarkdownDataContract(md="# New", url="https://example.com/docs/new", keywords="")
+        requests_mock.get(KB_FILES, json=kb_list_payload(("docs/keep.md", "id-keep"), ("docs/stale.md", "id-stale")))
+        requests_mock.post(STORAGE_UPLOAD, json={})  # keep updates OK
+        requests_mock.post(KB_FILES, exc=requests.exceptions.ConnectionError("create failed"))  # new fails
+        requests_mock.post(KB_SYNC, json={})
+        delete_mock = requests_mock.delete(KB_FILES, json={})
+
+        # One upload succeeds, one fails → not all failed (no raise), but prune is skipped.
+        assert prune_step.run([self.KEEP, new_doc]) == [self.KEEP, new_doc]
+        assert not delete_mock.called  # never delete to match an incomplete input

--- a/tests/steps/wonderful/step_test.py
+++ b/tests/steps/wonderful/step_test.py
@@ -209,6 +209,7 @@ class TestFailureScenarios:
     def test_missing_presigned_url_raises_step_failed(self, step, sample_doc, requests_mock):
         requests_mock.get(KB_FILES, json=kb_list_payload())
         requests_mock.post(KB_FILES, json={"data": {"id": "file-abc"}})  # no "url"
+        requests_mock.delete(f"{KB_FILES}/file-abc", json={})  # orphan rollback
 
         with pytest.raises(StepFailed, match="All 1 documents failed"):
             step.run([sample_doc])
@@ -266,6 +267,9 @@ class TestFailureScenarios:
             ],
         )
         requests_mock.post(KB_SYNC, json={})
+        # Either file could get the failing PUT (concurrent), so allow rollback of both.
+        requests_mock.delete(f"{KB_FILES}/file-1", json={})
+        requests_mock.delete(f"{KB_FILES}/file-2", json={})
 
         assert step.run(two_docs) == two_docs
 
@@ -451,3 +455,54 @@ class TestRetry:
             retry_step.run([sample_doc])
 
         assert sum(1 for r in requests_mock.request_history if r.method == "POST") == 3  # 3 attempts
+
+    def test_create_not_retried_on_read_timeout(self, retry_step, sample_doc, requests_mock):
+        """Create is non-idempotent: a read timeout must not be retried (avoids duplicates)."""
+        requests_mock.get(KB_FILES, json=kb_list_payload())
+        requests_mock.post(KB_FILES, exc=requests.exceptions.ReadTimeout("timeout"))
+
+        with pytest.raises(StepFailed):
+            retry_step.run([sample_doc])
+
+        assert sum(1 for r in requests_mock.request_history if r.method == "POST" and r.url == KB_FILES) == 1
+
+    def test_client_error_not_retried(self, retry_step, sample_doc, requests_mock):
+        """A 4xx is a permanent client error — no retry."""
+        requests_mock.get(KB_FILES, json=kb_list_payload())
+        requests_mock.post(KB_FILES, status_code=403)
+
+        with pytest.raises(StepFailed):
+            retry_step.run([sample_doc])
+
+        assert sum(1 for r in requests_mock.request_history if r.method == "POST" and r.url == KB_FILES) == 1
+
+    def test_server_error_is_retried(self, retry_step, sample_doc, requests_mock):
+        """A 5xx is transient — retried, then succeeds."""
+        requests_mock.get(KB_FILES, json=kb_list_payload())
+        requests_mock.post(
+            KB_FILES,
+            [
+                {"status_code": 503},
+                {"json": kb_create_payload("file-ok")},
+            ],
+        )
+        requests_mock.put(PRESIGNED)
+        requests_mock.post(KB_SYNC, json={})
+
+        result = retry_step.run([sample_doc])
+
+        assert result == [sample_doc]
+        assert sum(1 for r in requests_mock.request_history if r.method == "POST" and r.url == KB_FILES) == 2
+
+    def test_orphan_record_rolled_back_on_upload_failure(self, retry_step, sample_doc, requests_mock):
+        """If the S3 upload fails after the record is created, the record is deleted."""
+        file_id = "file-orphan"
+        requests_mock.get(KB_FILES, json=kb_list_payload())
+        requests_mock.post(KB_FILES, json=kb_create_payload(file_id))
+        requests_mock.put(PRESIGNED, exc=requests.exceptions.ConnectionError("s3 down"))
+        delete_mock = requests_mock.delete(f"{KB_FILES}/{file_id}", json={})
+
+        with pytest.raises(StepFailed):
+            retry_step.run([sample_doc])
+
+        assert delete_mock.called  # orphan record rolled back

--- a/tests/steps/wonderful/step_test.py
+++ b/tests/steps/wonderful/step_test.py
@@ -14,10 +14,10 @@ from wurzel.steps.wonderful import WonderfulRAGStep
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 KB_ID = "kb-123"
-BASE_URL = "https://tenant.api.wonderful.ai"
+BASE_URL = "https://tenant.api.wonderful.ai"  # host only; the step hardcodes /api/v1
 API = f"{BASE_URL}/api/v1"
 KB_FILES = f"{API}/knowledgebases/{KB_ID}/files"
-KB_SYNC = f"{KB_FILES}/sync"
+KB_SYNC = f"{API}/knowledgebases/{KB_ID}/sync"  # whole-KB sync (no per-file endpoint)
 STORAGE_UPLOAD = f"{API}/storage/upload"
 PRESIGNED = "https://s3.example.com/presigned"
 
@@ -152,7 +152,7 @@ class TestUpload:
 
         methods = [r.method for r in requests_mock.request_history]
         assert methods.count("GET") == 1
-        assert methods.count("POST") == 4  # 2× create + 2× sync
+        assert methods.count("POST") == 3  # 2× create + 1× whole-KB sync
         assert methods.count("PUT") == 2
 
     def test_input_deduped_by_filename(self, step, requests_mock):
@@ -209,12 +209,13 @@ class TestFailureScenarios:
     def test_missing_presigned_url_raises_step_failed(self, step, sample_doc, requests_mock):
         requests_mock.get(KB_FILES, json=kb_list_payload())
         requests_mock.post(KB_FILES, json={"data": {"id": "file-abc"}})  # no "url"
-        requests_mock.delete(f"{KB_FILES}/file-abc", json={})  # orphan rollback
+        requests_mock.delete(KB_FILES, json={})  # orphan rollback (batch delete)
 
         with pytest.raises(StepFailed, match="All 1 documents failed"):
             step.run([sample_doc])
 
-    def test_sync_failure_does_not_raise_when_others_succeed(self, step, two_docs, requests_mock):
+    def test_sync_failure_does_not_fail_step(self, step, two_docs, requests_mock):
+        # Sync is fire-and-forget: a sync error must NOT fail the step (uploads persisted).
         requests_mock.get(KB_FILES, json=kb_list_payload())
         requests_mock.post(
             KB_FILES,
@@ -224,16 +225,27 @@ class TestFailureScenarios:
             ],
         )
         requests_mock.put(PRESIGNED)
-        # First sync raises, second succeeds — both docs still pass through.
-        requests_mock.post(
-            KB_SYNC,
-            [
-                {"exc": requests.exceptions.ConnectionError("sync failed")},
-                {"json": {}},
-            ],
-        )
+        requests_mock.post(KB_SYNC, exc=requests.exceptions.ConnectionError("sync failed"))
 
         assert step.run(two_docs) == two_docs
+
+    def test_sync_524_does_not_fail_step(self, step, sample_doc, requests_mock):
+        # A Cloudflare 524 (gateway timeout) means indexing started server-side → don't fail.
+        requests_mock.get(KB_FILES, json=kb_list_payload())
+        requests_mock.post(KB_FILES, json=kb_create_payload("file-1"))
+        requests_mock.put(PRESIGNED)
+        requests_mock.post(KB_SYNC, status_code=524, text="<html>gateway timeout</html>")
+
+        assert step.run([sample_doc]) == [sample_doc]
+
+    def test_sync_timeout_does_not_fail_step(self, step, sample_doc, requests_mock):
+        # A client read timeout on the sync trigger is fire-and-forget → don't fail.
+        requests_mock.get(KB_FILES, json=kb_list_payload())
+        requests_mock.post(KB_FILES, json=kb_create_payload("file-1"))
+        requests_mock.put(PRESIGNED)
+        requests_mock.post(KB_SYNC, exc=requests.exceptions.ReadTimeout("slow"))
+
+        assert step.run([sample_doc]) == [sample_doc]
 
     def test_partial_kb_create_failure_does_not_raise(self, step, two_docs, requests_mock):
         requests_mock.get(KB_FILES, json=kb_list_payload())
@@ -267,9 +279,7 @@ class TestFailureScenarios:
             ],
         )
         requests_mock.post(KB_SYNC, json={})
-        # Either file could get the failing PUT (concurrent), so allow rollback of both.
-        requests_mock.delete(f"{KB_FILES}/file-1", json={})
-        requests_mock.delete(f"{KB_FILES}/file-2", json={})
+        requests_mock.delete(KB_FILES, json={})  # orphan rollback (batch delete)
 
         assert step.run(two_docs) == two_docs
 
@@ -427,24 +437,17 @@ class TestRetry:
         assert result == [sample_doc]
         assert sum(1 for r in requests_mock.request_history if r.method == "POST" and r.url == KB_FILES) == 3
 
-    def test_sync_retries_on_transient_error(self, retry_step, sample_doc, requests_mock):
-        """A transient sync failure is retried; success on the third attempt."""
+    def test_sync_triggered_once_not_retried(self, retry_step, sample_doc, requests_mock):
+        """Sync is fire-and-forget: triggered exactly once, never retried even on failure."""
         requests_mock.get(KB_FILES, json=kb_list_payload())
         requests_mock.post(KB_FILES, json=kb_create_payload("file-ok"))
         requests_mock.put(PRESIGNED)
-        requests_mock.post(
-            KB_SYNC,
-            [
-                {"exc": requests.exceptions.ConnectionError("transient")},
-                {"exc": requests.exceptions.ConnectionError("transient")},
-                {"json": {}},
-            ],
-        )
+        requests_mock.post(KB_SYNC, exc=requests.exceptions.ConnectionError("transient"))
 
         result = retry_step.run([sample_doc])
 
-        assert result == [sample_doc]
-        assert sum(1 for r in requests_mock.request_history if r.url.startswith(KB_SYNC)) == 3
+        assert result == [sample_doc]  # sync failure doesn't fail the step
+        assert sum(1 for r in requests_mock.request_history if r.url.startswith(KB_SYNC)) == 1
 
     def test_exhausted_retries_raises_step_failed(self, retry_step, sample_doc, requests_mock):
         """When all retries are exhausted and every document fails, StepFailed is raised."""
@@ -500,9 +503,10 @@ class TestRetry:
         requests_mock.get(KB_FILES, json=kb_list_payload())
         requests_mock.post(KB_FILES, json=kb_create_payload(file_id))
         requests_mock.put(PRESIGNED, exc=requests.exceptions.ConnectionError("s3 down"))
-        delete_mock = requests_mock.delete(f"{KB_FILES}/{file_id}", json={})
+        delete_mock = requests_mock.delete(KB_FILES, json={})
 
         with pytest.raises(StepFailed):
             retry_step.run([sample_doc])
 
         assert delete_mock.called  # orphan record rolled back
+        assert delete_mock.last_request.json() == {"file_ids": [file_id]}  # by id, in the body

--- a/tests/steps/wonderful/step_test.py
+++ b/tests/steps/wonderful/step_test.py
@@ -555,6 +555,23 @@ class TestPrune:
         sync_idx = next(i for i, (m, u) in enumerate(order) if m == "POST" and u.startswith(KB_SYNC))
         assert delete_idx < sync_idx
 
+    def test_prune_deletes_each_stale_file_concurrently(self, prune_step, requests_mock):
+        # Multiple stale files → one DELETE per file (per-worker), not a single giant batch.
+        requests_mock.get(
+            KB_FILES,
+            json=kb_list_payload(("docs/keep.md", "id-keep"), ("docs/stale1.md", "id-1"), ("docs/stale2.md", "id-2")),
+        )
+        requests_mock.post(STORAGE_UPLOAD, json={})
+        requests_mock.post(KB_SYNC, json={})
+        requests_mock.delete(KB_FILES, json={})
+
+        assert prune_step.run([self.KEEP]) == [self.KEEP]
+
+        deletes = [r for r in requests_mock.request_history if r.method == "DELETE"]
+        assert len(deletes) == 2  # one call per stale file
+        assert all(len(r.json()["file_ids"]) == 1 for r in deletes)  # single id each
+        assert sorted(r.json()["file_ids"][0] for r in deletes) == ["id-1", "id-2"]
+
     def test_prune_noop_when_kb_matches_input(self, prune_step, requests_mock):
         requests_mock.get(KB_FILES, json=kb_list_payload(("docs/keep.md", "id-keep")))  # KB == input
         requests_mock.post(STORAGE_UPLOAD, json={})
@@ -563,6 +580,29 @@ class TestPrune:
 
         assert prune_step.run([self.KEEP]) == [self.KEEP]
         assert not delete_mock.called  # nothing stale to delete
+
+    def test_prune_delete_not_retried_on_timeout(self, env, requests_mock, mocker):
+        # Even with MAX_RETRIES=3, a prune delete is attempted once; a read timeout is
+        # assumed completed server-side (not retried) so it doesn't pile load on the endpoint.
+        mocker.patch("wurzel.steps.wonderful.step.time.sleep")
+        env.set("BASE_URL", BASE_URL)
+        env.set("API_KEY", "test-api-key")
+        env.set("KNOWLEDGEBASE_ID", KB_ID)
+        env.set("MAX_RETRIES", "3")
+        env.set("RETRY_BACKOFF", "0")
+        env.set("PRUNE_STALE", "true")
+        step = WonderfulRAGStep()
+        try:
+            requests_mock.get(KB_FILES, json=kb_list_payload(("docs/keep.md", "id-keep"), ("docs/stale.md", "id-stale")))
+            requests_mock.post(STORAGE_UPLOAD, json={})
+            requests_mock.post(KB_SYNC, json={})
+            requests_mock.delete(KB_FILES, exc=requests.exceptions.ReadTimeout("slow delete"))
+
+            assert step.run([self.KEEP]) == [self.KEEP]
+            deletes = [r for r in requests_mock.request_history if r.method == "DELETE"]
+            assert len(deletes) == 1  # single attempt, no retry despite MAX_RETRIES=3
+        finally:
+            step.finalize()
 
     def test_prune_skipped_on_upload_failure(self, prune_step, requests_mock):
         new_doc = MarkdownDataContract(md="# New", url="https://example.com/docs/new", keywords="")

--- a/tests/steps/wonderful/step_test.py
+++ b/tests/steps/wonderful/step_test.py
@@ -43,6 +43,8 @@ def wonderful_env(env):
     env.set("BASE_URL", BASE_URL)
     env.set("API_KEY", "test-api-key")
     env.set("KNOWLEDGEBASE_ID", KB_ID)
+    env.set("MAX_RETRIES", "1")  # no retries in unit tests — keeps mocks simple
+    env.set("RETRY_BACKOFF", "0")  # no sleep in unit tests
     return env
 
 
@@ -328,8 +330,8 @@ class TestPerWorkerSession:
         spy = mocker.spy(step, "_build_session")
         step.run(two_docs)
 
-        # 1× main thread (existing-files fetch) + 2× workers (one per doc).
-        assert spy.call_count == 3
+        # 1× fetch + 2× upload workers + 1× sync loop.
+        assert spy.call_count == 4
 
 
 # ── Neverejny filter ──────────────────────────────────────────────────────────
@@ -376,3 +378,76 @@ class TestNeverejnyFilter:
         result = step.run(docs)
         assert result == docs  # passthrough unchanged
         assert requests_mock.request_history == []
+
+
+# ── Retry / back-off ──────────────────────────────────────────────────────────
+
+
+class TestRetry:
+    """Back-off retry is applied per HTTP call. Tests use MAX_RETRIES=3, RETRY_BACKOFF=0
+    (no actual sleep) so we can verify retry counts without slowing down the suite.
+    """
+
+    @pytest.fixture
+    def retry_env(self, env):
+        env.set("BASE_URL", BASE_URL)
+        env.set("API_KEY", "test-api-key")
+        env.set("KNOWLEDGEBASE_ID", KB_ID)
+        env.set("MAX_RETRIES", "3")
+        env.set("RETRY_BACKOFF", "0")
+        return env
+
+    @pytest.fixture
+    def retry_step(self, retry_env, mocker):
+        mocker.patch("wurzel.steps.wonderful.step.time.sleep")
+        s = WonderfulRAGStep()
+        yield s
+        s.finalize()
+
+    def test_upload_retries_on_transient_error(self, retry_step, sample_doc, requests_mock):
+        """A transient upload failure is retried; success on the third attempt."""
+        requests_mock.get(KB_FILES, json=kb_list_payload())
+        requests_mock.post(
+            KB_FILES,
+            [
+                {"exc": requests.exceptions.ConnectionError("transient")},
+                {"exc": requests.exceptions.ConnectionError("transient")},
+                {"json": kb_create_payload("file-ok")},
+            ],
+        )
+        requests_mock.put(PRESIGNED)
+        requests_mock.post(KB_SYNC, json={})
+
+        result = retry_step.run([sample_doc])
+
+        assert result == [sample_doc]
+        assert sum(1 for r in requests_mock.request_history if r.method == "POST" and r.url == KB_FILES) == 3
+
+    def test_sync_retries_on_transient_error(self, retry_step, sample_doc, requests_mock):
+        """A transient sync failure is retried; success on the third attempt."""
+        requests_mock.get(KB_FILES, json=kb_list_payload())
+        requests_mock.post(KB_FILES, json=kb_create_payload("file-ok"))
+        requests_mock.put(PRESIGNED)
+        requests_mock.post(
+            KB_SYNC,
+            [
+                {"exc": requests.exceptions.ConnectionError("transient")},
+                {"exc": requests.exceptions.ConnectionError("transient")},
+                {"json": {}},
+            ],
+        )
+
+        result = retry_step.run([sample_doc])
+
+        assert result == [sample_doc]
+        assert sum(1 for r in requests_mock.request_history if r.url.startswith(KB_SYNC)) == 3
+
+    def test_exhausted_retries_raises_step_failed(self, retry_step, sample_doc, requests_mock):
+        """When all retries are exhausted and every document fails, StepFailed is raised."""
+        requests_mock.get(KB_FILES, json=kb_list_payload())
+        requests_mock.post(KB_FILES, exc=requests.exceptions.ConnectionError("permanent"))
+
+        with pytest.raises(StepFailed):
+            retry_step.run([sample_doc])
+
+        assert sum(1 for r in requests_mock.request_history if r.method == "POST") == 3  # 3 attempts

--- a/wurzel/steps/wonderful/settings.py
+++ b/wurzel/steps/wonderful/settings.py
@@ -33,7 +33,7 @@ class WonderfulRAGSettings(Settings):
     )
     BASE_URL: str = Field(
         default="",
-        description="Wonderful API base URL (required when SKIP=false)",
+        description="Wonderful API base URL, e.g. https://<tenant>.api.sb.wonderful.ai (required when SKIP=false)",
     )
     API_KEY: SecretStr = Field(
         default=SecretStr(""),
@@ -47,6 +47,12 @@ class WonderfulRAGSettings(Settings):
         default=120,
         gt=0,
         description="Request timeout in seconds",
+    )
+    SYNC_TIMEOUT: int = Field(
+        default=30,
+        gt=0,
+        description="Timeout in seconds for the fire-and-forget KB sync trigger; the server keeps "
+        "indexing after the connection drops, so a timeout/524 here is not treated as a failure",
     )
     MAX_WORKERS: int = Field(
         default=10,

--- a/wurzel/steps/wonderful/settings.py
+++ b/wurzel/steps/wonderful/settings.py
@@ -53,6 +53,16 @@ class WonderfulRAGSettings(Settings):
         gt=0,
         description="Max concurrent upload workers",
     )
+    MAX_RETRIES: int = Field(
+        default=3,
+        gt=0,
+        description="Max attempts per HTTP call before giving up",
+    )
+    RETRY_BACKOFF: float = Field(
+        default=0.5,
+        ge=0,
+        description="Base delay in seconds for exponential back-off between retries (0 disables sleep): 0.5s, 1s, 2s, ...",
+    )
 
     @model_validator(mode="after")
     def _require_credentials_unless_skipped(self) -> "WonderfulRAGSettings":

--- a/wurzel/steps/wonderful/settings.py
+++ b/wurzel/steps/wonderful/settings.py
@@ -59,6 +59,11 @@ class WonderfulRAGSettings(Settings):
         gt=0,
         description="Max concurrent upload workers",
     )
+    PRUNE_STALE: bool = Field(
+        default=False,
+        description="When true, delete files present in the KB but absent from the input "
+        "(KB mirrors the input). Destructive; only runs when every upload succeeded.",
+    )
     MAX_RETRIES: int = Field(
         default=3,
         gt=0,

--- a/wurzel/steps/wonderful/step.py
+++ b/wurzel/steps/wonderful/step.py
@@ -30,15 +30,17 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
       Phase 1 (concurrent): upload or update each file's content
         New file:      POST /knowledgebases/{kb_id}/files  → PUT <presigned-url>
         Existing file: POST /storage/upload (multipart, file_id=<id>)
-      Phase 2 (sequential): POST /kb/files/sync per file to trigger re-indexing —
-        one at a time, because concurrent syncs overload the indexing endpoint and
-        cause read timeouts.
+      Phase 2 (fire-and-forget): POST /kb/sync once to re-index the whole KB. This
+        server op is slow and routinely exceeds the gateway timeout (~100s → HTTP 524);
+        the server keeps indexing after the connection drops, so the trigger is
+        fire-and-forget — a timeout/524 is logged, never raised.
 
-    Every HTTP call is retried with full-jitter exponential back-off on transient
+    Upload HTTP calls are retried with full-jitter exponential back-off on transient
     errors (connection errors, timeouts, HTTP 429/5xx). File creation is not retried
     on read timeouts because it is not idempotent — a re-sent create after the server
     already processed it would produce a duplicate record. If a record is created but
-    its content upload then fails, the orphan record is rolled back via DELETE.
+    its content upload then fails, the orphan record is rolled back via DELETE. The
+    sync trigger is not retried (fire-and-forget).
 
     Returns the input documents unchanged (passthrough sink) so the step can chain.
     Per-doc failures are logged but do not affect the output. If every document fails,
@@ -52,10 +54,11 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
 
     Environment Variables:
         WONDERFULRAGSTEP__SKIP:             When true, skip processing (default: false)
-        WONDERFULRAGSTEP__BASE_URL:         Wonderful API base URL (required when not SKIP)
+        WONDERFULRAGSTEP__BASE_URL:         Wonderful API base URL, e.g. https://<tenant>.api.sb.wonderful.ai (required when not SKIP)
         WONDERFULRAGSTEP__API_KEY:          API key (required when not SKIP)
         WONDERFULRAGSTEP__KNOWLEDGEBASE_ID: Knowledge base ID (required when not SKIP)
         WONDERFULRAGSTEP__TIMEOUT:          Request timeout in seconds (default: 120)
+        WONDERFULRAGSTEP__SYNC_TIMEOUT:     Fire-and-forget sync trigger timeout in seconds (default: 30)
         WONDERFULRAGSTEP__MAX_WORKERS:      Concurrent upload workers in phase 1 (default: 10)
         WONDERFULRAGSTEP__MAX_RETRIES:      Max attempts per HTTP call (default: 3)
         WONDERFULRAGSTEP__RETRY_BACKOFF:    Base back-off seconds — 0.5s, 1s, 2s, ... (default: 0.5)
@@ -142,24 +145,40 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
             log.debug(f"Response body ({response.status_code}): {response.text}")
         response.raise_for_status()
 
-    def _sync_kb_file(self, session: requests.Session, file_id: str) -> None:
-        """POST /kb/files/sync — trigger provider re-indexing for a single file."""
-        self._api_request(session, "POST", f"/knowledgebases/{self._kb_id}/files/sync", {"file_id": file_id})
+    def _trigger_sync(self, session: requests.Session) -> None:
+        """POST /kb/sync — fire-and-forget trigger of whole-KB re-indexing.
 
-    def _delete_kb_file(self, session: requests.Session, file_id: str) -> None:
-        """DELETE /kb/files/{id} — remove a file record (used to roll back orphans)."""
-        # Not routed through _api_request: a 204 No Content body would break response.json().
-        response = session.request(
-            "DELETE",
-            f"{self.settings.BASE_URL}/api/v1/knowledgebases/{self._kb_id}/files/{file_id}",
-            timeout=self.settings.TIMEOUT,
-        )
-        response.raise_for_status()
+        A single whole-KB sync is used rather than the per-file sync endpoint: each
+        sync (per-file or whole-KB) does heavy work and is slow regardless, so one call
+        is cheaper than one per file. The work is synchronous server-side and routinely
+        exceeds the gateway timeout (~100s → HTTP 524) and the client read timeout. The
+        server keeps indexing after the connection drops, so we only need to *trigger*
+        it: a timeout or 524 is logged as "started", never raised. Other errors are
+        logged but also do not fail the step (uploads are already persisted; re-running
+        re-triggers sync).
+        """
+        url = f"{self.settings.BASE_URL}/api/v1/knowledgebases/{self._kb_id}/sync"
+        try:
+            response = session.post(url, timeout=self.settings.SYNC_TIMEOUT)
+            if response.status_code in (502, 503, 504, 524):
+                log.info(f"KB sync triggered (gateway {response.status_code}); indexing continues server-side")
+            elif response.ok:
+                log.info(f"KB sync triggered ({response.status_code})")
+            else:
+                log.warning(f"KB sync trigger returned {response.status_code}: {response.text[:200]}")
+        except requests.exceptions.Timeout:
+            log.info("KB sync triggered (client timeout); indexing continues server-side")
+        except requests.exceptions.RequestException as e:
+            log.warning(f"KB sync trigger could not be sent: {e}")
+
+    def _delete_kb_files(self, session: requests.Session, file_ids: list[str]) -> None:
+        """DELETE /kb/files — remove file records by id (batch endpoint, ids in the body)."""
+        self._api_request(session, "DELETE", f"/knowledgebases/{self._kb_id}/files", {"file_ids": file_ids})
 
     def _delete_kb_file_safe(self, session: requests.Session, file_id: str, filename: str) -> None:
         """Best-effort rollback of a created-but-not-uploaded record. Never raises."""
         try:
-            self._delete_kb_file(session, file_id)
+            self._delete_kb_files(session, [file_id])
             log.info(f"Rolled back orphaned record for {filename}")
         except requests.exceptions.RequestException as e:
             log.warning(f"Could not roll back orphaned record {file_id} for {filename}: {e}")
@@ -225,8 +244,8 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
         """Upload (or update) a single document. Returns file_id on success, None on failure.
 
         Each worker uses its own ``requests.Session`` because Session is not
-        thread-safe for concurrent use. Sync is intentionally excluded here and
-        handled sequentially in phase 2 to avoid overloading the re-indexing endpoint.
+        thread-safe for concurrent use. Sync is intentionally excluded here — a single
+        whole-KB sync is triggered once in phase 2 after all uploads.
         """
         filename = self._generate_filename(doc, idx)
         existing_id = existing.get(filename)
@@ -250,20 +269,6 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
             except (requests.exceptions.RequestException, KeyError) as e:
                 log.error(f"Failed to upload {filename}: {e}")
                 return None
-
-    # ── Phase 2: sequential sync ──────────────────────────────────────────────
-
-    def _sync_all(self, file_ids: list[str]) -> int:
-        """Sync each file sequentially. Returns the number of failures."""
-        failed = 0
-        with self._build_session() as session:
-            for file_id in file_ids:
-                try:
-                    self._with_retry(self._sync_kb_file, session, file_id)
-                except requests.exceptions.RequestException as e:
-                    log.error(f"Failed to sync file {file_id}: {e}")
-                    failed += 1
-        return failed
 
     # ── Main run ──────────────────────────────────────────────────────────────
 
@@ -309,17 +314,17 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
         uploaded = [fid for fid in file_ids if fid is not None]
         upload_failed = len(deduped) - len(uploaded)
         if upload_failed:
-            log.warning(f"Upload phase: {upload_failed} document(s) failed")
+            log.warning(f"Upload phase: {upload_failed} of {len(deduped)} document(s) failed")
+        if not uploaded:
+            raise StepFailed(f"All {len(deduped)} documents failed to upload")
 
-        # Phase 2: sync uploaded files sequentially — avoids hammering the
-        # re-indexing endpoint with concurrent requests that cause timeouts.
-        sync_failed = self._sync_all(uploaded)
+        # Phase 2: trigger a single whole-KB re-index (fire-and-forget). The sync is a
+        # slow server-side op that exceeds the gateway timeout; we trigger it and let the
+        # server finish indexing in the background rather than blocking/failing on it.
+        with self._build_session() as session:
+            self._trigger_sync(session)
 
-        failed = upload_failed + sync_failed
-        log.info(f"Completed: {len(deduped) - failed} succeeded, {failed} failed")
-
-        if failed == len(deduped):
-            raise StepFailed(f"All {failed} documents failed to process")
+        log.info(f"Completed: {len(uploaded)} file(s) uploaded, KB sync triggered, {upload_failed} upload failure(s)")
 
         # Passthrough preserves the original input length and order.
         return inpt

--- a/wurzel/steps/wonderful/step.py
+++ b/wurzel/steps/wonderful/step.py
@@ -186,27 +186,48 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
         except requests.exceptions.RequestException as e:
             log.warning(f"Could not roll back orphaned record {file_id} for {filename}: {e}")
 
+    def _prune_one(self, file_id: str, filename: str) -> bool:
+        """Delete a single stale file (own session per worker). Returns True on success.
+
+        Not retried: the DELETE is slow, and a read timeout almost always means the server
+        is still completing the delete — retrying only piles more load on the endpoint. So a
+        read timeout is treated as "assume deleted"; other errors count as failures.
+        """
+        with self._build_session() as session:
+            try:
+                self._delete_kb_files(session, [file_id])
+                return True
+            except requests.exceptions.ReadTimeout:
+                log.info(f"Prune of {filename} timed out (read); assuming the server completes it")
+                return True
+            except requests.exceptions.RequestException as e:
+                log.warning(f"Failed to prune {filename} ({file_id}): {e}")
+                return False
+
     def _prune_stale(self, existing: dict[str, str], keep_filenames: set[str]) -> int:
         """Delete files in the KB that are not in the input, so the KB mirrors the input.
 
         ``existing`` is the pre-upload {filename: file_id} snapshot, so this only removes
         files that were already in the KB and are absent from the input (KB − input) —
         never anything created this run. Reading the snapshot before uploading also avoids
-        read-after-write lag. Best-effort: a delete failure is logged, not raised.
-        Returns the number of files pruned.
+        read-after-write lag.
+
+        Deletes run concurrently, one file per worker — same pool model as the upload
+        phase. A single batch DELETE with the whole id list does not scale (the endpoint
+        404s on large lists); per-file calls do. Best-effort: per-file failures are logged,
+        not raised. Returns the number of files actually pruned.
         """
         stale = {fid: name for name, fid in existing.items() if name not in keep_filenames}
         if not stale:
             return 0
         sample = sorted(stale.values())
         log.info(f"Pruning {len(stale)} stale file(s) not in input: {sample[:10]}{' ...' if len(sample) > 10 else ''}")
-        try:
-            with self._build_session() as session:
-                self._with_retry(self._delete_kb_files, session, list(stale.keys()))
-            return len(stale)
-        except requests.exceptions.RequestException as e:
-            log.warning(f"Failed to prune {len(stale)} stale file(s): {e}")
-            return 0
+        with ThreadPoolExecutor(max_workers=self.settings.MAX_WORKERS) as executor:
+            futures = [executor.submit(self._prune_one, fid, name) for fid, name in stale.items()]
+            pruned = sum(1 for f in as_completed(futures) if f.result())
+        if pruned < len(stale):
+            log.warning(f"Pruned {pruned}/{len(stale)} stale file(s); {len(stale) - pruned} could not be deleted")
+        return pruned
 
     # ── Filename generation ───────────────────────────────────────────────────
 

--- a/wurzel/steps/wonderful/step.py
+++ b/wurzel/steps/wonderful/step.py
@@ -26,9 +26,19 @@ log = getLogger(__name__)
 class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract], list[MarkdownDataContract]]):
     """Wonderful RAG connector step.
 
-    Each document runs fully concurrently (upload + sync in the same worker thread):
-      New file:      POST /knowledgebases/{kb_id}/files  → PUT <presigned-url>  → POST /kb/files/sync
-      Existing file: POST /storage/upload (multipart, file_id=<id>)             → POST /kb/files/sync
+    Documents are processed in two phases:
+      Phase 1 (concurrent): upload or update each file's content
+        New file:      POST /knowledgebases/{kb_id}/files  → PUT <presigned-url>
+        Existing file: POST /storage/upload (multipart, file_id=<id>)
+      Phase 2 (sequential): POST /kb/files/sync per file to trigger re-indexing —
+        one at a time, because concurrent syncs overload the indexing endpoint and
+        cause read timeouts.
+
+    Every HTTP call is retried with full-jitter exponential back-off on transient
+    errors (connection errors, timeouts, HTTP 429/5xx). File creation is not retried
+    on read timeouts because it is not idempotent — a re-sent create after the server
+    already processed it would produce a duplicate record. If a record is created but
+    its content upload then fails, the orphan record is rolled back via DELETE.
 
     Returns the input documents unchanged (passthrough sink) so the step can chain.
     Per-doc failures are logged but do not affect the output. If every document fails,
@@ -46,7 +56,9 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
         WONDERFULRAGSTEP__API_KEY:          API key (required when not SKIP)
         WONDERFULRAGSTEP__KNOWLEDGEBASE_ID: Knowledge base ID (required when not SKIP)
         WONDERFULRAGSTEP__TIMEOUT:          Request timeout in seconds (default: 120)
-        WONDERFULRAGSTEP__MAX_WORKERS:      Concurrent workers — each handles upload + sync (default: 10)
+        WONDERFULRAGSTEP__MAX_WORKERS:      Concurrent upload workers in phase 1 (default: 10)
+        WONDERFULRAGSTEP__MAX_RETRIES:      Max attempts per HTTP call (default: 3)
+        WONDERFULRAGSTEP__RETRY_BACKOFF:    Base back-off seconds — 0.5s, 1s, 2s, ... (default: 0.5)
     """
 
     def __init__(self) -> None:
@@ -134,6 +146,24 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
         """POST /kb/files/sync — trigger provider re-indexing for a single file."""
         self._api_request(session, "POST", f"/knowledgebases/{self._kb_id}/files/sync", {"file_id": file_id})
 
+    def _delete_kb_file(self, session: requests.Session, file_id: str) -> None:
+        """DELETE /kb/files/{id} — remove a file record (used to roll back orphans)."""
+        # Not routed through _api_request: a 204 No Content body would break response.json().
+        response = session.request(
+            "DELETE",
+            f"{self.settings.BASE_URL}/api/v1/knowledgebases/{self._kb_id}/files/{file_id}",
+            timeout=self.settings.TIMEOUT,
+        )
+        response.raise_for_status()
+
+    def _delete_kb_file_safe(self, session: requests.Session, file_id: str, filename: str) -> None:
+        """Best-effort rollback of a created-but-not-uploaded record. Never raises."""
+        try:
+            self._delete_kb_file(session, file_id)
+            log.info(f"Rolled back orphaned record for {filename}")
+        except requests.exceptions.RequestException as e:
+            log.warning(f"Could not roll back orphaned record {file_id} for {filename}: {e}")
+
     # ── Filename generation ───────────────────────────────────────────────────
 
     def _generate_filename(self, doc: MarkdownDataContract, idx: int) -> str:
@@ -149,23 +179,45 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
 
     # ── Retry helper ──────────────────────────────────────────────────────────
 
-    def _with_retry(self, fn: Callable, *args, **kwargs) -> Any:
-        """Call fn(*args, **kwargs) with exponential back-off retry on request errors.
+    @staticmethod
+    def _should_retry(exc: requests.exceptions.RequestException, idempotent: bool) -> bool:
+        """Whether ``exc`` is a transient error worth retrying.
 
-        Only ``requests.exceptions.RequestException`` is retried; all other
-        exceptions propagate immediately.
+        - Read timeout: the server may already have processed the request, so only
+          retry idempotent calls — re-sending a create would duplicate the record.
+        - Connect timeout / connection error: the request never completed at the
+          server, so it is always safe to retry.
+        - HTTP 429 / 5xx: transient server-side, safe to retry.
+        - Other 4xx: permanent client error, never retry.
         """
-        last_exc: Exception = RuntimeError("unreachable")
+        if isinstance(exc, requests.exceptions.ReadTimeout):
+            return idempotent
+        if isinstance(exc, (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError)):
+            return True
+        if isinstance(exc, requests.exceptions.Timeout):
+            return idempotent
+        if isinstance(exc, requests.exceptions.HTTPError) and exc.response is not None:
+            return exc.response.status_code == 429 or exc.response.status_code >= 500
+        return False
+
+    def _with_retry(self, fn: Callable, *args, idempotent: bool = True, **kwargs) -> Any:
+        """Call fn(*args, **kwargs) with full-jitter exponential back-off retry.
+
+        Only transient request errors are retried (see ``_should_retry``); permanent
+        errors propagate immediately. Pass ``idempotent=False`` for calls that must
+        not be re-sent after a read timeout (e.g. record creation).
+        """
         for attempt in range(self.settings.MAX_RETRIES):
             try:
                 return fn(*args, **kwargs)
             except requests.exceptions.RequestException as exc:
-                last_exc = exc
-                if attempt < self.settings.MAX_RETRIES - 1:
-                    delay = random.uniform(0, self.settings.RETRY_BACKOFF * (2**attempt))
-                    log.warning(f"Attempt {attempt + 1}/{self.settings.MAX_RETRIES} failed: {exc}; retrying in {delay:.2f}s")
-                    time.sleep(delay)
-        raise last_exc
+                is_last = attempt == self.settings.MAX_RETRIES - 1
+                if is_last or not self._should_retry(exc, idempotent):
+                    raise
+                delay = random.uniform(0, self.settings.RETRY_BACKOFF * (2**attempt))
+                log.warning(f"Attempt {attempt + 1}/{self.settings.MAX_RETRIES} failed: {exc}; retrying in {delay:.2f}s")
+                time.sleep(delay)
+        raise RuntimeError("unreachable: retry loop exited without returning or raising")
 
     # ── Per-document upload (phase 1) ─────────────────────────────────────────
 
@@ -184,10 +236,17 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
                     self._with_retry(self._update_existing_file, session, existing_id, filename, doc.md.encode("utf-8"))
                     log.info(f"Updated: {filename}")
                     return existing_id
-                kb_file = self._with_retry(self._create_kb_file, session, filename)
-                self._with_retry(self._upload_to_presigned_url, kb_file["url"], doc.md.encode("utf-8"))
+                # Create is not idempotent — don't re-send it on a read timeout.
+                kb_file = self._with_retry(self._create_kb_file, session, filename, idempotent=False)
+                file_id = kb_file["id"]
+                try:
+                    self._with_retry(self._upload_to_presigned_url, kb_file["url"], doc.md.encode("utf-8"))
+                except (requests.exceptions.RequestException, KeyError):
+                    # Record exists but has no content — roll it back to avoid an orphan.
+                    self._delete_kb_file_safe(session, file_id, filename)
+                    raise
                 log.info(f"Uploaded: {filename}")
-                return kb_file["id"]
+                return file_id
             except (requests.exceptions.RequestException, KeyError) as e:
                 log.error(f"Failed to upload {filename}: {e}")
                 return None
@@ -210,19 +269,21 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
 
     def run(self, inpt: list[MarkdownDataContract]) -> list[MarkdownDataContract]:
         """Upload and sync markdown documents to the Wonderful RAG knowledge base."""
-        if self.settings.SKIP:
-            log.info(f"WonderfulRAGStep skipped — passing through {len(inpt)} documents unchanged")
-            return inpt
         if not inpt:
             log.warning("No documents to process")
             return []
 
+        # Filter before the SKIP check so a dry run reflects the real upload set.
         # "neverejn" matches both Czech genders: neverejny (masc.) and neverejna (fem.)
         # .casefold() ensures case-insensitive matching (e.g. Neverejny, NEVEREJNY).
         to_upload = [doc for doc in inpt if "neverejn" not in doc.url.casefold()]
         excluded = len(inpt) - len(to_upload)
         if excluded:
             log.info(f"Excluded {excluded} document(s) with 'neverejn' in URL")
+
+        if self.settings.SKIP:
+            log.info(f"WonderfulRAGStep skipped — would upload {len(to_upload)} of {len(inpt)} document(s), no API calls")
+            return inpt
         if not to_upload:
             return inpt
 

--- a/wurzel/steps/wonderful/step.py
+++ b/wurzel/steps/wonderful/step.py
@@ -4,6 +4,9 @@
 
 """Wonderful RAG connector step for pushing markdown documents to a knowledge base."""
 
+import random
+import time
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from logging import getLogger
 from typing import Any
@@ -144,34 +147,64 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
                 return path if path.endswith(".md") else path + ".md"
         return f"document_{idx:04d}.md"
 
-    # ── Per-document: upload + sync in one worker ─────────────────────────────
+    # ── Retry helper ──────────────────────────────────────────────────────────
 
-    def _process_doc(self, idx: int, doc: MarkdownDataContract, existing: dict[str, str]) -> bool:
-        """Upload (or update) a single document and sync it. Returns True on success.
+    def _with_retry(self, fn: Callable, *args, **kwargs) -> Any:
+        """Call fn(*args, **kwargs) with exponential back-off retry on request errors.
 
-        Each worker uses its own `requests.Session` because `Session` is not
-        thread-safe for concurrent use.
+        Only ``requests.exceptions.RequestException`` is retried; all other
+        exceptions propagate immediately.
+        """
+        last_exc: Exception = RuntimeError("unreachable")
+        for attempt in range(self.settings.MAX_RETRIES):
+            try:
+                return fn(*args, **kwargs)
+            except requests.exceptions.RequestException as exc:
+                last_exc = exc
+                if attempt < self.settings.MAX_RETRIES - 1:
+                    delay = random.uniform(0, self.settings.RETRY_BACKOFF * (2**attempt))
+                    log.warning(f"Attempt {attempt + 1}/{self.settings.MAX_RETRIES} failed: {exc}; retrying in {delay:.2f}s")
+                    time.sleep(delay)
+        raise last_exc
+
+    # ── Per-document upload (phase 1) ─────────────────────────────────────────
+
+    def _upload_doc(self, idx: int, doc: MarkdownDataContract, existing: dict[str, str]) -> str | None:
+        """Upload (or update) a single document. Returns file_id on success, None on failure.
+
+        Each worker uses its own ``requests.Session`` because Session is not
+        thread-safe for concurrent use. Sync is intentionally excluded here and
+        handled sequentially in phase 2 to avoid overloading the re-indexing endpoint.
         """
         filename = self._generate_filename(doc, idx)
         existing_id = existing.get(filename)
         with self._build_session() as session:
             try:
                 if existing_id:
-                    self._update_existing_file(session, existing_id, filename, doc.md.encode("utf-8"))
-                    file_id = existing_id
-                    log.info(f"Updating: {filename}")
-                else:
-                    kb_file = self._create_kb_file(session, filename)
-                    self._upload_to_presigned_url(kb_file["url"], doc.md.encode("utf-8"))
-                    file_id = kb_file["id"]
-                    log.info(f"Uploading: {filename}")
-
-                self._sync_kb_file(session, file_id)
-                return True
-
+                    self._with_retry(self._update_existing_file, session, existing_id, filename, doc.md.encode("utf-8"))
+                    log.info(f"Updated: {filename}")
+                    return existing_id
+                kb_file = self._with_retry(self._create_kb_file, session, filename)
+                self._with_retry(self._upload_to_presigned_url, kb_file["url"], doc.md.encode("utf-8"))
+                log.info(f"Uploaded: {filename}")
+                return kb_file["id"]
             except (requests.exceptions.RequestException, KeyError) as e:
-                log.error(f"Failed to process {filename}: {e}")
-                return False
+                log.error(f"Failed to upload {filename}: {e}")
+                return None
+
+    # ── Phase 2: sequential sync ──────────────────────────────────────────────
+
+    def _sync_all(self, file_ids: list[str]) -> int:
+        """Sync each file sequentially. Returns the number of failures."""
+        failed = 0
+        with self._build_session() as session:
+            for file_id in file_ids:
+                try:
+                    self._with_retry(self._sync_kb_file, session, file_id)
+                except requests.exceptions.RequestException as e:
+                    log.error(f"Failed to sync file {file_id}: {e}")
+                    failed += 1
+        return failed
 
     # ── Main run ──────────────────────────────────────────────────────────────
 
@@ -203,16 +236,26 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
         if len(deduped) < len(to_upload):
             log.info(f"Deduped input: {len(to_upload)} → {len(deduped)} unique filenames")
 
-        log.info(f"Uploading {len(deduped)} documents to Wonderful KB {self._kb_id}")
+        log.info(f"Processing {len(deduped)} documents for Wonderful KB {self._kb_id}")
         with self._build_session() as session:
             existing = self._fetch_existing_filenames(session)
 
+        # Phase 1: upload files concurrently — pure I/O, benefits from parallelism.
         with ThreadPoolExecutor(max_workers=self.settings.MAX_WORKERS) as executor:
-            futures = [executor.submit(self._process_doc, idx, doc, existing) for idx, doc in deduped]
-            success_count = sum(1 for f in as_completed(futures) if f.result())
+            futures = [executor.submit(self._upload_doc, idx, doc, existing) for idx, doc in deduped]
+            file_ids = [f.result() for f in as_completed(futures)]
 
-        failed = len(deduped) - success_count
-        log.info(f"Completed: {success_count} succeeded, {failed} failed")
+        uploaded = [fid for fid in file_ids if fid is not None]
+        upload_failed = len(deduped) - len(uploaded)
+        if upload_failed:
+            log.warning(f"Upload phase: {upload_failed} document(s) failed")
+
+        # Phase 2: sync uploaded files sequentially — avoids hammering the
+        # re-indexing endpoint with concurrent requests that cause timeouts.
+        sync_failed = self._sync_all(uploaded)
+
+        failed = upload_failed + sync_failed
+        log.info(f"Completed: {len(deduped) - failed} succeeded, {failed} failed")
 
         if failed == len(deduped):
             raise StepFailed(f"All {failed} documents failed to process")

--- a/wurzel/steps/wonderful/step.py
+++ b/wurzel/steps/wonderful/step.py
@@ -30,6 +30,8 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
       Phase 1 (concurrent): upload or update each file's content
         New file:      POST /knowledgebases/{kb_id}/files  → PUT <presigned-url>
         Existing file: POST /storage/upload (multipart, file_id=<id>)
+      Prune (optional, gated by PRUNE_STALE): before sync, delete files that are in the
+        KB but not in the input so the KB mirrors the input. Skipped on any upload failure.
       Phase 2 (fire-and-forget): POST /kb/sync once to re-index the whole KB. This
         server op is slow and routinely exceeds the gateway timeout (~100s → HTTP 524);
         the server keeps indexing after the connection drops, so the trigger is
@@ -60,6 +62,7 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
         WONDERFULRAGSTEP__TIMEOUT:          Request timeout in seconds (default: 120)
         WONDERFULRAGSTEP__SYNC_TIMEOUT:     Fire-and-forget sync trigger timeout in seconds (default: 30)
         WONDERFULRAGSTEP__MAX_WORKERS:      Concurrent upload workers in phase 1 (default: 10)
+        WONDERFULRAGSTEP__PRUNE_STALE:      Delete KB files absent from input, mirroring it (default: false)
         WONDERFULRAGSTEP__MAX_RETRIES:      Max attempts per HTTP call (default: 3)
         WONDERFULRAGSTEP__RETRY_BACKOFF:    Base back-off seconds — 0.5s, 1s, 2s, ... (default: 0.5)
     """
@@ -182,6 +185,28 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
             log.info(f"Rolled back orphaned record for {filename}")
         except requests.exceptions.RequestException as e:
             log.warning(f"Could not roll back orphaned record {file_id} for {filename}: {e}")
+
+    def _prune_stale(self, existing: dict[str, str], keep_filenames: set[str]) -> int:
+        """Delete files in the KB that are not in the input, so the KB mirrors the input.
+
+        ``existing`` is the pre-upload {filename: file_id} snapshot, so this only removes
+        files that were already in the KB and are absent from the input (KB − input) —
+        never anything created this run. Reading the snapshot before uploading also avoids
+        read-after-write lag. Best-effort: a delete failure is logged, not raised.
+        Returns the number of files pruned.
+        """
+        stale = {fid: name for name, fid in existing.items() if name not in keep_filenames}
+        if not stale:
+            return 0
+        sample = sorted(stale.values())
+        log.info(f"Pruning {len(stale)} stale file(s) not in input: {sample[:10]}{' ...' if len(sample) > 10 else ''}")
+        try:
+            with self._build_session() as session:
+                self._with_retry(self._delete_kb_files, session, list(stale.keys()))
+            return len(stale)
+        except requests.exceptions.RequestException as e:
+            log.warning(f"Failed to prune {len(stale)} stale file(s): {e}")
+            return 0
 
     # ── Filename generation ───────────────────────────────────────────────────
 
@@ -318,13 +343,23 @@ class WonderfulRAGStep(TypedStep[WonderfulRAGSettings, list[MarkdownDataContract
         if not uploaded:
             raise StepFailed(f"All {len(deduped)} documents failed to upload")
 
+        # Optional prune (before sync): make the KB mirror the input by deleting stale
+        # files (KB − input). Gated behind PRUNE_STALE and skipped on any upload failure,
+        # so we never delete real content to match an incomplete input.
+        pruned = 0
+        if self.settings.PRUNE_STALE:
+            if upload_failed:
+                log.warning(f"Skipping prune: {upload_failed} upload(s) failed this run")
+            else:
+                pruned = self._prune_stale(existing, set(unique.keys()))
+
         # Phase 2: trigger a single whole-KB re-index (fire-and-forget). The sync is a
         # slow server-side op that exceeds the gateway timeout; we trigger it and let the
         # server finish indexing in the background rather than blocking/failing on it.
         with self._build_session() as session:
             self._trigger_sync(session)
 
-        log.info(f"Completed: {len(uploaded)} file(s) uploaded, KB sync triggered, {upload_failed} upload failure(s)")
+        log.info(f"Completed: {len(uploaded)} file(s) uploaded, {pruned} pruned, KB sync triggered, {upload_failed} upload failure(s)")
 
         # Passthrough preserves the original input length and order.
         return inpt


### PR DESCRIPTION
## Summary

Hardens the `WonderfulRAGStep` connector and aligns it with the **live** Wonderful API (verified against the matej-sb OpenAPI spec and a full 461-document ingestion run). Resolves the production read-timeout failures.

### What changed

- **Two-phase processing.** Phase 1 uploads/updates files concurrently (pure I/O). Phase 2 triggers indexing once. Previously upload+sync were interleaved across 10 workers, which hammered the slow sync endpoint and caused read timeouts.
- **Fire-and-forget sync.** The KB re-index (`POST /knowledgebases/{id}/sync`) is slow server-side and routinely exceeds the gateway timeout (~100s → HTTP 524). The server keeps indexing after the connection drops, so the trigger is fire-and-forget: a timeout/524 is logged as "started", never raised. New `SYNC_TIMEOUT` setting (default 30s).
- **Scoped retries with full-jitter back-off.** Only transient errors retry (timeouts, connection errors, HTTP 429/5xx); 4xx fails fast. File creation is **not** retried on a read timeout (non-idempotent → would duplicate the record). `MAX_RETRIES` (3) and `RETRY_BACKOFF` (0.5s → 1s → 2s) settings.
- **Orphan rollback.** If a record is created but its content upload then fails, the record is deleted (`DELETE /knowledgebases/{id}/files` with `{file_ids:[...]}`) so no content-less orphan is left behind.
- **Private-document filter.** Documents whose URL contains `neverejn` (Czech `neverejny`/`neverejna`, case-insensitive) are excluded from upload. Runs before the SKIP check so a dry run reflects the real upload set.
- **Optional prune (`PRUNE_STALE`, default off).** Before sync, delete files in the KB that are absent from the input so the KB mirrors the input. Computed from the pre-upload snapshot (lag-safe), and **skipped on any upload failure** so we never delete real content to match an incomplete input. Also clears private files already in the KB, which the upload filter alone cannot remove.
- **Passthrough preserved.** The step returns its input unchanged so it can chain.

### New settings (all `WONDERFULRAGSTEP__`)

| Setting | Default | Purpose |
|---|---|---|
| `SYNC_TIMEOUT` | 30 | Fire-and-forget sync trigger timeout (s) |
| `MAX_RETRIES` | 3 | Max attempts per HTTP call |
| `RETRY_BACKOFF` | 0.5 | Base back-off seconds (full jitter) |
| `PRUNE_STALE` | false | Delete KB files absent from input |

### Validation

- Full live run against matej-sb: **461/461 files uploaded, 0 failures**; sync triggered fire-and-forget; step exits 0.
- Read-back reconcile: 0 missing files in the KB.
- 41 unit tests (requests-mock), covering upload/update, dedup, retry scoping, idempotency, orphan rollback, neverejn filter, fire-and-forget sync, and prune guardrails.

## Test plan

- [ ] `uv run pytest tests/steps/wonderful/step_test.py -v`
- [ ] Live: full ingestion completes without StepFailed despite slow sync
- [ ] `PRUNE_STALE=true` removes stale + private files; skipped when an upload fails
- [ ] Retry: transient errors retried, 4xx fails fast, create not retried on read timeout
