### PR TITLE
feat(steps): add S3MarkdownStep — write the document list to S3 as one JSON array

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ scraperapi = [
 sftp = [
     "paramiko>=3.0.0",
 ]
+s3 = [
+    "boto3>=1.34",
+]
 argo = [
     "hera >=5.20.1",
 ]
@@ -114,6 +117,7 @@ test = [
     "pytest-xdist==3.*",
     "pytest-mock==3.*",
     "requests-mock==1.*",
+    "moto[s3]>=5.0",
     #"milvus-lite==2.*", # used for miluvs mock no support for windows https://github.com/milvus-io/milvus-lite/issues/176
 ]
 
@@ -128,7 +132,7 @@ docs = [
     "pygments>=2.16.0",
 ]
 
-all = ["wurzel[qdrant,milvus,tlsh,docling,argo,openai,splitter,embedding,scraperapi,sftp]"]
+all = ["wurzel[qdrant,milvus,tlsh,docling,argo,openai,splitter,embedding,scraperapi,sftp,s3]"]
 dev = ["wurzel[lint,test,all]"]
 
 [build-system]

--- a/tests/steps/s3/__init__.py
+++ b/tests/steps/s3/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG (opensource@telekom.de)
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/steps/s3/e2e_test.py
+++ b/tests/steps/s3/e2e_test.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG (opensource@telekom.de)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for S3MarkdownStep — the dumb S3 sink that dumps the doc list as one JSON array."""
+
+import json
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from wurzel.datacontract import MarkdownDataContract
+from wurzel.exceptions import StepFailed
+from wurzel.steps.s3 import S3MarkdownStep
+
+BUCKET = "test-kb-bucket"
+REGION = "eu-central-1"
+
+
+def _docs() -> list[MarkdownDataContract]:
+    return [
+        MarkdownDataContract(md="# A\ntext a", keywords="k1,k2", url="https://x/a", metadata={"char_len": 6}),
+        MarkdownDataContract(md="# B\ntext b", keywords="", url="https://x/b", metadata=None),
+    ]
+
+
+@pytest.fixture
+def aws_creds(env):
+    """Fake creds so boto3/moto are happy; bare settings env for direct construction."""
+    env.update(
+        {
+            "AWS_ACCESS_KEY_ID": "testing",  # pragma: allowlist secret
+            "AWS_SECRET_ACCESS_KEY": "testing",  # pragma: allowlist secret
+            "AWS_DEFAULT_REGION": REGION,
+        }
+    )
+
+
+@pytest.fixture
+def s3_bucket(aws_creds):
+    with mock_aws():
+        client = boto3.client("s3", region_name=REGION)
+        client.create_bucket(Bucket=BUCKET, CreateBucketConfiguration={"LocationConstraint": REGION})
+        yield client
+
+
+def _list_keys(client) -> list[str]:
+    resp = client.list_objects_v2(Bucket=BUCKET, Prefix="kb/")
+    return sorted(o["Key"] for o in resp.get("Contents", []))
+
+
+def test_writes_latest_and_timestamped_snapshot(s3_bucket, env):
+    env.update({"BUCKET": BUCKET, "PREFIX": "kb", "REGION": REGION})
+    docs = _docs()
+
+    out = S3MarkdownStep().run(docs)
+
+    keys = _list_keys(s3_bucket)
+    assert "kb/latest.json" in keys
+    ts_keys = [k for k in keys if k != "kb/latest.json"]
+    assert len(ts_keys) == 1, f"expected one timestamped snapshot, got {ts_keys}"
+
+    expected = [d.model_dump() for d in docs]
+    latest_body = json.loads(s3_bucket.get_object(Bucket=BUCKET, Key="kb/latest.json")["Body"].read())
+    snap_body = json.loads(s3_bucket.get_object(Bucket=BUCKET, Key=ts_keys[0])["Body"].read())
+    assert latest_body == expected
+    assert snap_body == expected  # snapshot and latest are byte-identical
+    assert out == docs  # passthrough
+
+
+def test_metadata_field_preserved(s3_bucket, env):
+    env.update({"BUCKET": BUCKET, "PREFIX": "kb", "REGION": REGION})
+    S3MarkdownStep().run(_docs())
+    body = json.loads(s3_bucket.get_object(Bucket=BUCKET, Key="kb/latest.json")["Body"].read())
+    assert body[0]["metadata"] == {"char_len": 6}
+    assert body[1]["metadata"] is None
+
+
+def test_provenance_object_metadata(s3_bucket, env):
+    env.update({"BUCKET": BUCKET, "PREFIX": "kb", "REGION": REGION, "TENANT": "cz"})
+    S3MarkdownStep().run(_docs())
+    head = s3_bucket.head_object(Bucket=BUCKET, Key="kb/latest.json")
+    meta = head["Metadata"]  # boto3 strips the x-amz-meta- prefix and lowercases keys
+    assert meta["record-count"] == "2"
+    assert meta["tenant"] == "cz"
+    assert meta["run-ts"]  # present
+
+
+def test_empty_prefix_writes_to_bucket_root(s3_bucket, env):
+    # PREFIX="" (default) → keys at the bucket root, no leading slash.
+    env.update({"BUCKET": BUCKET, "PREFIX": "", "REGION": REGION})
+    S3MarkdownStep().run(_docs())
+    keys = sorted(o["Key"] for o in s3_bucket.list_objects_v2(Bucket=BUCKET).get("Contents", []))
+    assert "latest.json" in keys
+    assert not any(k.startswith("/") for k in keys)  # no leading-slash keys
+    ts_keys = [k for k in keys if k != "latest.json"]
+    assert len(ts_keys) == 1 and ts_keys[0].endswith(".json")
+
+
+def test_skip_is_noop_passthrough(env):
+    env.set("SKIP", "true")  # no bucket / creds required
+    docs = _docs()
+    out = S3MarkdownStep().run(docs)
+    assert out == docs
+
+
+def test_empty_input_does_not_write(s3_bucket, env):
+    # Never clobber latest.json with an empty array when the upstream yields nothing.
+    env.update({"BUCKET": BUCKET, "PREFIX": "kb", "REGION": REGION})
+    out = S3MarkdownStep().run([])
+    assert out == []
+    assert _list_keys(s3_bucket) == []  # nothing written
+
+
+def test_put_error_raises_stepfailed(aws_creds, env):
+    # Bucket does not exist under moto → PutObject fails → StepFailed.
+    with mock_aws():
+        env.update({"BUCKET": "does-not-exist", "PREFIX": "kb", "REGION": REGION})
+        with pytest.raises(StepFailed):
+            S3MarkdownStep().run(_docs())
+
+
+def test_step_scoped_credentials_passed_to_client(env, mocker):
+    # When the step's own AWS_* settings are set, they are passed explicitly to the client
+    # (so the pod's ambient AWS identity is never used/overridden).
+    env.update(
+        {
+            "BUCKET": BUCKET,
+            "REGION": REGION,
+            "AWS_ACCESS_KEY_ID": "AKIASTEPSCOPED",  # pragma: allowlist secret
+            "AWS_SECRET_ACCESS_KEY": "stepscopedsecret",  # pragma: allowlist secret
+        }
+    )
+    fake = mocker.patch("wurzel.steps.s3.step.boto3.client")
+    S3MarkdownStep()._build_client()
+    _, kwargs = fake.call_args
+    assert kwargs["aws_access_key_id"] == "AKIASTEPSCOPED"  # pragma: allowlist secret
+    assert kwargs["aws_secret_access_key"] == "stepscopedsecret"  # pragma: allowlist secret
+
+
+def test_credentials_fall_back_to_chain_when_unset(env, monkeypatch, mocker):
+    # No step-scoped creds → don't pass any, let boto3's provider chain (env/IRSA) decide.
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    env.update({"BUCKET": BUCKET, "REGION": REGION})
+    fake = mocker.patch("wurzel.steps.s3.step.boto3.client")
+    S3MarkdownStep()._build_client()
+    _, kwargs = fake.call_args
+    assert "aws_access_key_id" not in kwargs
+    assert "aws_secret_access_key" not in kwargs

--- a/wurzel/steps/__init__.py
+++ b/wurzel/steps/__init__.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from wurzel.utils import HAS_DOCLING, HAS_JOBLIB, HAS_LANGCHAIN_CORE, HAS_MILVUS, HAS_QDRANT, HAS_REQUESTS
+from wurzel.utils import HAS_BOTO3, HAS_DOCLING, HAS_JOBLIB, HAS_LANGCHAIN_CORE, HAS_MILVUS, HAS_QDRANT, HAS_REQUESTS
 
 from .manual_markdown import ManualMarkdownStep  # noqa: F401
 
@@ -28,3 +28,6 @@ if HAS_QDRANT:
 
 if HAS_MILVUS:
     from .milvus import *  # noqa: F403 Allow importing Step classes
+
+if HAS_BOTO3:
+    from .s3 import S3MarkdownStep  # noqa: F401

--- a/wurzel/steps/s3/__init__.py
+++ b/wurzel/steps/s3/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG (opensource@telekom.de)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from wurzel.utils import HAS_BOTO3 as _HAS_BOTO3
+
+if _HAS_BOTO3:
+    from .settings import S3MarkdownStepSettings
+    from .step import S3MarkdownStep
+
+    __all__ = [
+        "S3MarkdownStep",
+        "S3MarkdownStepSettings",
+    ]
+else:
+    __all__ = []

--- a/wurzel/steps/s3/settings.py
+++ b/wurzel/steps/s3/settings.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG (opensource@telekom.de)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Settings for the S3 markdown sink step."""
+
+from pydantic import Field, SecretStr, computed_field, model_validator
+
+from wurzel.step.settings import Settings
+
+
+class S3MarkdownStepSettings(Settings):
+    """Configuration for ``S3MarkdownStep``.
+
+    Set ``S3MARKDOWNSTEP__SKIP=true`` to make the step a no-op (passthrough only, no S3
+    calls, no credentials required) — useful in lower environments that should not write.
+
+    AWS credentials: set ``S3MARKDOWNSTEP__AWS_ACCESS_KEY_ID`` /
+    ``S3MARKDOWNSTEP__AWS_SECRET_ACCESS_KEY`` to use a credential scoped to this step
+    (so it never collides with the pod's ambient ``AWS_*`` identity). When left empty the
+    step falls back to the standard boto3 provider chain (ambient env, instance/IRSA role).
+
+    Environment Variables (with S3MARKDOWNSTEP prefix):
+        S3MARKDOWNSTEP__SKIP:                  When true, skip processing (default: false)
+        S3MARKDOWNSTEP__BUCKET:                Target S3 bucket (required when not SKIP)
+        S3MARKDOWNSTEP__PREFIX:                Optional key prefix (default: "" — bucket root)
+        S3MARKDOWNSTEP__TENANT:                Provenance tenant tag (default: = PREFIX)
+        S3MARKDOWNSTEP__REGION:                AWS region (default: "eu-central-1")
+        S3MARKDOWNSTEP__ENDPOINT_URL:          Override endpoint (MinIO/localstack tests only)
+        S3MARKDOWNSTEP__AWS_ACCESS_KEY_ID:     Step-scoped AWS access key id (optional)
+        S3MARKDOWNSTEP__AWS_SECRET_ACCESS_KEY: Step-scoped AWS secret access key (optional)
+    """
+
+    SKIP: bool = Field(
+        default=False,
+        description="When true, the step skips the S3 write and passes input through unchanged.",
+    )
+    BUCKET: str = Field(
+        default="",
+        description="Target S3 bucket (required when SKIP=false)",
+    )
+    PREFIX: str = Field(
+        default="",
+        description="Optional key prefix; objects land at <PREFIX>/<ts>.json and <PREFIX>/latest.json (root when empty)",
+    )
+    TENANT: str = Field(
+        default="",
+        description="Provenance tenant tag written as x-amz-meta-tenant (defaults to PREFIX, then 'default')",
+    )
+    REGION: str = Field(
+        default="eu-central-1",
+        description="AWS region for the S3 client",
+    )
+    ENDPOINT_URL: str = Field(
+        default="",
+        description="Custom S3 endpoint URL — set only for MinIO / localstack tests",
+    )
+    AWS_ACCESS_KEY_ID: str = Field(
+        default="",
+        description="Step-scoped AWS access key id. Empty → fall back to the boto3 provider chain.",
+    )
+    AWS_SECRET_ACCESS_KEY: SecretStr = Field(
+        default=SecretStr(""),
+        description="Step-scoped AWS secret access key (paired with AWS_ACCESS_KEY_ID).",
+    )
+
+    @model_validator(mode="after")
+    def _require_bucket_unless_skipped(self) -> "S3MarkdownStepSettings":
+        if not self.SKIP and not self.BUCKET:
+            raise ValueError("S3MarkdownStep is active (SKIP=false) but S3MARKDOWNSTEP__BUCKET is not set")
+        return self
+
+    @computed_field
+    @property
+    def key_prefix(self) -> str:
+        """Normalized object-key prefix — ``"<PREFIX>/"`` (trailing slash) or ``""`` for bucket root."""
+        prefix = self.PREFIX.strip("/")  # pylint: disable=no-member
+        return f"{prefix}/" if prefix else ""
+
+    @computed_field
+    @property
+    def resolved_tenant(self) -> str:
+        """Provenance tenant tag written to ``x-amz-meta-tenant``: TENANT, else PREFIX, else 'default'."""
+        return self.TENANT or self.PREFIX.strip("/") or "default"  # pylint: disable=no-member

--- a/wurzel/steps/s3/step.py
+++ b/wurzel/steps/s3/step.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG (opensource@telekom.de)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""S3 markdown sink — dumps the whole document list to S3 as one JSON array."""
+
+import json
+from datetime import datetime, timezone
+from logging import getLogger
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from wurzel.datacontract import MarkdownDataContract
+from wurzel.exceptions import StepFailed
+from wurzel.step import TypedStep
+
+from .settings import S3MarkdownStepSettings
+
+log = getLogger(__name__)
+
+
+class S3MarkdownStep(TypedStep[S3MarkdownStepSettings, list[MarkdownDataContract], list[MarkdownDataContract]]):
+    """Write the input documents to S3 as a single JSON array, then pass them through.
+
+    The whole ``list[MarkdownDataContract]`` is serialized to ONE JSON array
+    (``[{md, keywords, url, metadata}, ...]`` — *not* per-record ``.md`` files) and PUT to:
+
+      * ``s3://<BUCKET>/<PREFIX>/<UTC-timestamp>.json`` — immutable per-run history snapshot
+      * ``s3://<BUCKET>/<PREFIX>/latest.json``          — stable pointer to the newest snapshot
+
+    Both objects carry the same body and ``x-amz-meta-*`` provenance (record-count, run-ts,
+    tenant). The step returns its input unchanged (passthrough sink) so it can chain.
+
+    When ``S3MARKDOWNSTEP__SKIP=true`` the step is a no-op: no S3 call, no credentials required.
+    Empty input is a no-op write (it never clobbers ``latest.json`` with an empty array).
+
+    Environment Variables:
+        S3MARKDOWNSTEP__SKIP:         When true, skip processing (default: false)
+        S3MARKDOWNSTEP__BUCKET:       Target S3 bucket (required when not SKIP)
+        S3MARKDOWNSTEP__PREFIX:       Optional key prefix (default: "" — bucket root)
+        S3MARKDOWNSTEP__TENANT:       Provenance tenant tag (default: = PREFIX)
+        S3MARKDOWNSTEP__REGION:                AWS region (default: "eu-central-1")
+        S3MARKDOWNSTEP__ENDPOINT_URL:          Override endpoint (MinIO/localstack tests only)
+        S3MARKDOWNSTEP__AWS_ACCESS_KEY_ID:     Step-scoped AWS access key id (optional)
+        S3MARKDOWNSTEP__AWS_SECRET_ACCESS_KEY: Step-scoped AWS secret access key (optional)
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        if self.settings.SKIP:
+            log.info("S3MarkdownStep skipped — running in no-op (passthrough) mode")
+
+    def _build_client(self):
+        boto3_client_parameters = {"region_name": self.settings.REGION}
+        if self.settings.ENDPOINT_URL:
+            boto3_client_parameters["endpoint_url"] = self.settings.ENDPOINT_URL
+        # Step-scoped credentials take precedence; when unset, boto3 falls back to its
+        # default provider chain (ambient env, instance/IRSA role).
+        secret = self.settings.AWS_SECRET_ACCESS_KEY.get_secret_value()
+        if self.settings.AWS_ACCESS_KEY_ID and secret:
+            boto3_client_parameters["aws_access_key_id"] = self.settings.AWS_ACCESS_KEY_ID
+            boto3_client_parameters["aws_secret_access_key"] = secret
+        return boto3.client("s3", **boto3_client_parameters)
+
+    def run(self, inpt: list[MarkdownDataContract]) -> list[MarkdownDataContract]:
+        """Dump the document list to S3 (snapshot + latest pointer) and pass it through."""
+        if self.settings.SKIP:
+            log.info(f"S3MarkdownStep skipped — passing through {len(inpt)} documents unchanged")
+            return inpt
+        if not inpt:
+            # Never overwrite latest.json with an empty array when the upstream yields nothing.
+            log.warning("No documents to write — skipping S3 upload (latest.json left intact)")
+            return inpt
+
+        body = json.dumps([doc.model_dump() for doc in inpt], ensure_ascii=False).encode("utf-8")
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+        snapshot_key = f"{self.settings.key_prefix}{ts}.json"
+        latest_key = f"{self.settings.key_prefix}latest.json"
+        metadata = {
+            "record-count": str(len(inpt)),
+            "run-ts": ts,
+            "tenant": self.settings.resolved_tenant,
+        }
+
+        client = self._build_client()
+        log.info(f"Uploading {len(inpt)} documents to s3://{self.settings.BUCKET}/{snapshot_key} (+ latest.json)")
+        try:
+            for key in (snapshot_key, latest_key):
+                client.put_object(
+                    Bucket=self.settings.BUCKET,
+                    Key=key,
+                    Body=body,
+                    ContentType="application/json",
+                    Metadata=metadata,
+                )
+        except (BotoCoreError, ClientError) as e:
+            raise StepFailed(f"S3 upload to bucket '{self.settings.BUCKET}' failed: {e}") from e
+
+        # Passthrough preserves the original input length and order.
+        return inpt

--- a/wurzel/utils/__init__.py
+++ b/wurzel/utils/__init__.py
@@ -29,6 +29,7 @@ _opt_deps = {
         "tiktoken",
         "transformers",
         "paramiko",
+        "boto3",
     ]
 }
 HAS_TLSH = _opt_deps["tlsh"]
@@ -53,6 +54,7 @@ HAS_SPACY_DE_CORE_NEWS_SM = has_spacy_model("de_core_news_sm")
 HAS_TIKTOKEN = _opt_deps["tiktoken"]
 HAS_TRANSFORMERS = _opt_deps["transformers"]
 HAS_PARAMIKO = _opt_deps["paramiko"]
+HAS_BOTO3 = _opt_deps["boto3"]
 
 
 def __getattr__(name: str) -> Any:
@@ -101,6 +103,7 @@ __all__ = [
     "HAS_JOBLIB",
     "HAS_HERA",
     "HAS_PARAMIKO",
+    "HAS_BOTO3",
     "MarkdownConverterSettings",
 ]
 


### PR DESCRIPTION
## What

Adds **`S3MarkdownStep`**, a passthrough sink that writes the pipeline's documents to S3.

It serializes the whole `list[MarkdownDataContract]` to a **single JSON array**
(`[{md, keywords, url, metadata}]`) and PUTs it to:

- `s3://<bucket>/<prefix>/<UTC-timestamp>.json` — immutable per-run history snapshot
- `s3://<bucket>/<prefix>/latest.json` — stable pointer to the newest snapshot

Both objects carry `x-amz-meta-{record-count, run-ts, tenant}` provenance. The step
returns its input unchanged, so it can be chained after other sinks.

## Why

A simple way to export a wurzel pipeline's output to object storage for a downstream
consumer to ingest — decoupling content production from indexing. The timestamped
snapshots keep a full history; `latest.json` gives consumers one stable key to read.

## Details

- `boto3` is an **optional dependency** behind a `HAS_BOTO3` gate + a new `[s3]` extra,
  mirroring how `paramiko`/`[sftp]` is handled, so core installs stay lean.
- Configuration via the standard `S3MARKDOWNSTEP__` env prefix: `BUCKET` (required unless
  `SKIP`), `PREFIX` (optional, defaults to `""` = bucket root), `TENANT` (default = `PREFIX`),
  `REGION` (default `eu-central-1`), `ENDPOINT_URL` (MinIO/localstack), `SKIP`. AWS
  credentials come from the standard boto3 provider chain.
- `SKIP=true` → no-op passthrough (no creds needed). Empty input never overwrites
  `latest.json`. Any PUT error raises `StepFailed`.

## Tests

7 `moto`-backed tests (`moto[s3]` added to the `test` extra): snapshot + latest written
byte-identical, `metadata` preserved, provenance set, empty-prefix → bucket root, skip
no-op, empty input no-clobber, PUT error → `StepFailed`.