### PR TITLE
feat: add Wurzel step observability metrics

### DIFF
--- a/docs/backends/argoworkflows.md
+++ b/docs/backends/argoworkflows.md
@@ -377,9 +377,12 @@ container:
   labels should be added by scrape or Pushgateway relabeling.
 
 For Argo workflows, `run_id` is set from `{{workflow.uid}}`. The Prometheus
-middleware derives `workflow_name` from `HOSTNAME`, so no additional values file
-configuration is required for Grafana correlation with pod phase, CPU, memory,
-and resource request metrics.
+middleware reads the backend-neutral Wurzel runtime context. The Argo backend
+maps `{{workflow.uid}}` to `WURZEL_RUN_ID` and `{{workflow.name}}` to
+`WURZEL_WORKFLOW_NAME`, so the middleware does not inspect Kubernetes-specific
+environment variables. Namespace and pod labels can still be added by scrape or
+Pushgateway relabeling for Grafana correlation with pod phase, CPU, memory, and
+resource request metrics.
 
 For more details on middlewares, see the [Middleware Documentation](../executor/middlewares.md).
 

--- a/docs/backends/argoworkflows.md
+++ b/docs/backends/argoworkflows.md
@@ -366,23 +366,20 @@ container:
 
 **Metrics Collected:**
 
-- Compatibility counters and histograms:
-  `steps_started`, `steps_failed`, `step_inputs`, `step_results`,
-  `step_hist_load`, `step_hist_execute`, `step_hist_save`, and
-  `step_datacontract_metric`.
-- Observability gauges:
-  `wurzel_step_input_items`, `wurzel_step_result_items`,
-  `wurzel_step_duration_seconds`, `wurzel_step_status`,
-  `wurzel_step_timestamp_seconds`, and `wurzel_step_info`.
-- Compatibility labels: `step_name`, `run_id` from `WURZEL_RUN_ID`.
-- Observability labels:
-  `step_name`, `run_id`, `workflow_name`, `workflow_namespace`, and `step_pod`.
-  The Prometheus Pushgateway adds the pipeline `job` label.
+- `wurzel_step_input_items` and `wurzel_step_result_items` for per-step item counts.
+- `wurzel_step_duration_seconds` for `load`, `execute`, `save`, and `total` phases.
+- `wurzel_step_status` for `started`, `succeeded`, and `failed` status.
+- `wurzel_step_timestamp_seconds` for `started`, `completed`, and `failed` lifecycle events.
+- `wurzel_step_info` for static step metadata.
+- `wurzel_step_datacontract_metric` for data contract metrics by `metric_name`.
+- Labels: `step_name`, `run_id`, `workflow_name`, and `step_pod`.
+  The Prometheus Pushgateway adds the pipeline `job` label. Namespace labels
+  should be added by scrape or Pushgateway relabeling.
 
 For Argo workflows, `run_id` is set from `{{workflow.uid}}`. The Prometheus
-middleware derives the workflow pod and namespace context from the running
-Kubernetes pod, so no additional values file configuration is required for
-Grafana correlation with pod phase, CPU, memory, and resource request metrics.
+middleware derives the workflow pod context from `HOSTNAME`, so no additional
+values file configuration is required for Grafana correlation with pod phase,
+CPU, memory, and resource request metrics.
 
 For more details on middlewares, see the [Middleware Documentation](../executor/middlewares.md).
 

--- a/docs/backends/argoworkflows.md
+++ b/docs/backends/argoworkflows.md
@@ -372,17 +372,16 @@ container:
 - `wurzel_step_timestamp_seconds` for `started`, `completed`, and `failed` lifecycle events.
 - `wurzel_step_info` for static step metadata.
 - `wurzel_step_datacontract_metric` for data contract metrics by `metric_name`.
-- Labels: `step_name`, `run_id`, and `workflow_name`.
-  The Prometheus Pushgateway adds the pipeline `job` label. Namespace and pod
-  labels should be added by scrape or Pushgateway relabeling.
+- Labels: `step_name` and `run_id`.
+  The Prometheus Pushgateway adds the pipeline `job` label. Namespace, pod, and
+  workflow labels should be added by scrape or Pushgateway relabeling.
 
 For Argo workflows, `run_id` is set from `{{workflow.uid}}`. The Prometheus
 middleware reads the backend-neutral Wurzel runtime context. The Argo backend
-maps `{{workflow.uid}}` to `WURZEL_RUN_ID` and `{{workflow.name}}` to
-`WURZEL_WORKFLOW_NAME`, so the middleware does not inspect Kubernetes-specific
-environment variables. Namespace and pod labels can still be added by scrape or
-Pushgateway relabeling for Grafana correlation with pod phase, CPU, memory, and
-resource request metrics.
+maps `{{workflow.uid}}` to `WURZEL_RUN_ID`, so the middleware does not inspect
+Kubernetes-specific environment variables. Namespace, pod, and workflow labels
+can still be added by scrape or Pushgateway relabeling for Grafana correlation
+with pod phase, CPU, memory, and resource request metrics.
 
 For more details on middlewares, see the [Middleware Documentation](../executor/middlewares.md).
 

--- a/docs/backends/argoworkflows.md
+++ b/docs/backends/argoworkflows.md
@@ -366,9 +366,23 @@ container:
 
 **Metrics Collected:**
 
-- `step_duration_seconds` - Histogram of step execution duration
-- `step_executions_total` - Counter of step executions
-- Labels: `step_name`, `run_id` (from `WURZEL_RUN_ID`)
+- Compatibility counters and histograms:
+  `steps_started`, `steps_failed`, `step_inputs`, `step_results`,
+  `step_hist_load`, `step_hist_execute`, `step_hist_save`, and
+  `step_datacontract_metric`.
+- Observability gauges:
+  `wurzel_step_input_items`, `wurzel_step_result_items`,
+  `wurzel_step_duration_seconds`, `wurzel_step_status`,
+  `wurzel_step_timestamp_seconds`, and `wurzel_step_info`.
+- Compatibility labels: `step_name`, `run_id` from `WURZEL_RUN_ID`.
+- Observability labels:
+  `step_name`, `run_id`, `workflow_name`, `workflow_namespace`, and `step_pod`.
+  The Prometheus Pushgateway adds the pipeline `job` label.
+
+For Argo workflows, `run_id` is set from `{{workflow.uid}}`. The Prometheus
+middleware derives the workflow pod and namespace context from the running
+Kubernetes pod, so no additional values file configuration is required for
+Grafana correlation with pod phase, CPU, memory, and resource request metrics.
 
 For more details on middlewares, see the [Middleware Documentation](../executor/middlewares.md).
 

--- a/docs/backends/argoworkflows.md
+++ b/docs/backends/argoworkflows.md
@@ -372,14 +372,14 @@ container:
 - `wurzel_step_timestamp_seconds` for `started`, `completed`, and `failed` lifecycle events.
 - `wurzel_step_info` for static step metadata.
 - `wurzel_step_datacontract_metric` for data contract metrics by `metric_name`.
-- Labels: `step_name`, `run_id`, `workflow_name`, and `step_pod`.
-  The Prometheus Pushgateway adds the pipeline `job` label. Namespace labels
-  should be added by scrape or Pushgateway relabeling.
+- Labels: `step_name`, `run_id`, and `workflow_name`.
+  The Prometheus Pushgateway adds the pipeline `job` label. Namespace and pod
+  labels should be added by scrape or Pushgateway relabeling.
 
 For Argo workflows, `run_id` is set from `{{workflow.uid}}`. The Prometheus
-middleware derives the workflow pod context from `HOSTNAME`, so no additional
-values file configuration is required for Grafana correlation with pod phase,
-CPU, memory, and resource request metrics.
+middleware derives `workflow_name` from `HOSTNAME`, so no additional values file
+configuration is required for Grafana correlation with pod phase, CPU, memory,
+and resource request metrics.
 
 For more details on middlewares, see the [Middleware Documentation](../executor/middlewares.md).
 

--- a/docs/executor/middlewares.md
+++ b/docs/executor/middlewares.md
@@ -124,11 +124,30 @@ Settings use the `PROMETHEUS__` prefix (pydantic-settings applies it automatical
 | `PROMETHEUS__JOB` | `default-job-name` | Job name for metrics |
 | `PROMETHEUS__DISABLE_CREATED_METRIC` | `true` | Disable `*_created` metrics |
 
-**Metrics emitted** (labels: `step_name`, `run_id` from `WURZEL_RUN_ID`):
+**Compatibility metrics emitted** (labels: `step_name`, `run_id` from `WURZEL_RUN_ID`):
 
 - `steps_started`, `steps_failed`, `step_results`, `step_inputs` — Counters
 - `step_hist_load`, `step_hist_execute`, `step_hist_save` — Histograms
 - `step_datacontract_metric` — Gauge for data contract metrics
+
+**Observability metrics emitted**:
+
+These gauges are intended for dashboards that correlate Wurzel step results with
+Argo workflow pods and Kubernetes resource metrics. They all include
+`step_name`, `run_id`, `workflow_name`, `workflow_namespace`, and `step_pod`
+labels. The Prometheus Pushgateway supplies the pipeline `job` label.
+
+- `wurzel_step_input_items` — Total input items processed by the step.
+- `wurzel_step_result_items` — Total result items produced by the step.
+- `wurzel_step_duration_seconds` — Step duration by `phase` (`load`, `execute`, `save`, `total`).
+- `wurzel_step_status` — Current step status by `status` (`started`, `succeeded`, `failed`).
+- `wurzel_step_timestamp_seconds` — Step lifecycle timestamps by `event` (`started`, `completed`, `failed`).
+- `wurzel_step_info` — Static value of `1` with the correlation labels.
+
+For Argo runs, the middleware derives `step_pod` from `HOSTNAME`,
+`workflow_name` from the pod name prefix before `-wurzel-run-template-`, and
+`workflow_namespace` from the Kubernetes service account namespace file. Local
+or non-Kubernetes runs use `unknown` for unavailable context labels.
 
 For DVC, export the env vars before `dvc repro`. For Argo, add them to
 `container.env` in your `values.yaml`. See the

--- a/docs/executor/middlewares.md
+++ b/docs/executor/middlewares.md
@@ -128,9 +128,9 @@ Settings use the `PROMETHEUS__` prefix (pydantic-settings applies it automatical
 
 These gauges are intended for dashboards that correlate Wurzel step results with
 Argo workflow pods and Kubernetes resource metrics. They all include
-`step_name`, `run_id`, and `workflow_name` labels. The Prometheus Pushgateway
-supplies the pipeline `job` label. Namespace and pod labels should be added by
-the Prometheus scrape or Pushgateway relabeling configuration.
+`step_name` and `run_id` labels. The Prometheus Pushgateway supplies the
+pipeline `job` label. Namespace, pod, and workflow labels should be added by the
+Prometheus scrape or Pushgateway relabeling configuration.
 
 - `wurzel_step_input_items` — Total input items processed by the step.
 - `wurzel_step_result_items` — Total result items produced by the step.
@@ -141,10 +141,10 @@ the Prometheus scrape or Pushgateway relabeling configuration.
 - `wurzel_step_datacontract_metric` — Data contract metrics by `metric_name`.
 
 The middleware reads backend-neutral Wurzel runtime context only:
-`WURZEL_RUN_ID` and `WURZEL_WORKFLOW_NAME`. Backends are responsible for mapping
-their own runtime information into these Wurzel-owned variables. The middleware
-does not inspect backend-specific environment variables such as Kubernetes pod
-metadata. Local runs use `unknown` for unavailable context labels.
+`WURZEL_RUN_ID`. Backends are responsible for mapping their own runtime
+information into this Wurzel-owned variable. The middleware does not inspect
+backend-specific environment variables such as Kubernetes pod metadata. Local
+runs use `unknown` when the run id is unavailable.
 
 For DVC, export the env vars before `dvc repro`. For Argo, add them to
 `container.env` in your `values.yaml`. See the

--- a/docs/executor/middlewares.md
+++ b/docs/executor/middlewares.md
@@ -137,12 +137,14 @@ the Prometheus scrape or Pushgateway relabeling configuration.
 - `wurzel_step_duration_seconds` — Step duration by `phase` (`load`, `execute`, `save`, `total`).
 - `wurzel_step_status` — Current step status by `status` (`started`, `succeeded`, `failed`).
 - `wurzel_step_timestamp_seconds` — Step lifecycle timestamps by `event` (`started`, `completed`, `failed`).
-- `wurzel_step_info` — Static value of `1` with the correlation labels.
+- `wurzel_step_info` — Static value of `1` with the Wurzel runtime context labels.
 - `wurzel_step_datacontract_metric` — Data contract metrics by `metric_name`.
 
-For Argo runs, the middleware derives `workflow_name` from the `HOSTNAME` prefix
-before `-wurzel-run-template-`. Local or non-Kubernetes runs use `unknown` for
-unavailable context labels.
+The middleware reads backend-neutral Wurzel runtime context only:
+`WURZEL_RUN_ID` and `WURZEL_WORKFLOW_NAME`. Backends are responsible for mapping
+their own runtime information into these Wurzel-owned variables. The middleware
+does not inspect backend-specific environment variables such as Kubernetes pod
+metadata. Local runs use `unknown` for unavailable context labels.
 
 For DVC, export the env vars before `dvc repro`. For Argo, add them to
 `container.env` in your `values.yaml`. See the

--- a/docs/executor/middlewares.md
+++ b/docs/executor/middlewares.md
@@ -128,9 +128,9 @@ Settings use the `PROMETHEUS__` prefix (pydantic-settings applies it automatical
 
 These gauges are intended for dashboards that correlate Wurzel step results with
 Argo workflow pods and Kubernetes resource metrics. They all include
-`step_name`, `run_id`, `workflow_name`, and `step_pod` labels. The Prometheus
-Pushgateway supplies the pipeline `job` label. Namespace labels should be added
-by the Prometheus scrape or Pushgateway relabeling configuration.
+`step_name`, `run_id`, and `workflow_name` labels. The Prometheus Pushgateway
+supplies the pipeline `job` label. Namespace and pod labels should be added by
+the Prometheus scrape or Pushgateway relabeling configuration.
 
 - `wurzel_step_input_items` — Total input items processed by the step.
 - `wurzel_step_result_items` — Total result items produced by the step.
@@ -140,9 +140,9 @@ by the Prometheus scrape or Pushgateway relabeling configuration.
 - `wurzel_step_info` — Static value of `1` with the correlation labels.
 - `wurzel_step_datacontract_metric` — Data contract metrics by `metric_name`.
 
-For Argo runs, the middleware derives `step_pod` from `HOSTNAME`,
-`workflow_name` from the pod name prefix before `-wurzel-run-template-`. Local
-or non-Kubernetes runs use `unknown` for unavailable context labels.
+For Argo runs, the middleware derives `workflow_name` from the `HOSTNAME` prefix
+before `-wurzel-run-template-`. Local or non-Kubernetes runs use `unknown` for
+unavailable context labels.
 
 For DVC, export the env vars before `dvc repro`. For Argo, add them to
 `container.env` in your `values.yaml`. See the

--- a/docs/executor/middlewares.md
+++ b/docs/executor/middlewares.md
@@ -124,18 +124,13 @@ Settings use the `PROMETHEUS__` prefix (pydantic-settings applies it automatical
 | `PROMETHEUS__JOB` | `default-job-name` | Job name for metrics |
 | `PROMETHEUS__DISABLE_CREATED_METRIC` | `true` | Disable `*_created` metrics |
 
-**Compatibility metrics emitted** (labels: `step_name`, `run_id` from `WURZEL_RUN_ID`):
-
-- `steps_started`, `steps_failed`, `step_results`, `step_inputs` — Counters
-- `step_hist_load`, `step_hist_execute`, `step_hist_save` — Histograms
-- `step_datacontract_metric` — Gauge for data contract metrics
-
-**Observability metrics emitted**:
+**Metrics emitted**:
 
 These gauges are intended for dashboards that correlate Wurzel step results with
 Argo workflow pods and Kubernetes resource metrics. They all include
-`step_name`, `run_id`, `workflow_name`, `workflow_namespace`, and `step_pod`
-labels. The Prometheus Pushgateway supplies the pipeline `job` label.
+`step_name`, `run_id`, `workflow_name`, and `step_pod` labels. The Prometheus
+Pushgateway supplies the pipeline `job` label. Namespace labels should be added
+by the Prometheus scrape or Pushgateway relabeling configuration.
 
 - `wurzel_step_input_items` — Total input items processed by the step.
 - `wurzel_step_result_items` — Total result items produced by the step.
@@ -143,10 +138,10 @@ labels. The Prometheus Pushgateway supplies the pipeline `job` label.
 - `wurzel_step_status` — Current step status by `status` (`started`, `succeeded`, `failed`).
 - `wurzel_step_timestamp_seconds` — Step lifecycle timestamps by `event` (`started`, `completed`, `failed`).
 - `wurzel_step_info` — Static value of `1` with the correlation labels.
+- `wurzel_step_datacontract_metric` — Data contract metrics by `metric_name`.
 
 For Argo runs, the middleware derives `step_pod` from `HOSTNAME`,
-`workflow_name` from the pod name prefix before `-wurzel-run-template-`, and
-`workflow_namespace` from the Kubernetes service account namespace file. Local
+`workflow_name` from the pod name prefix before `-wurzel-run-template-`. Local
 or non-Kubernetes runs use `unknown` for unavailable context labels.
 
 For DVC, export the env vars before `dvc repro`. For Argo, add them to

--- a/tests/backend/test_backend_run_id.py
+++ b/tests/backend/test_backend_run_id.py
@@ -11,6 +11,7 @@ from wurzel.core import NoSettings, TypedStep
 from wurzel.datacontract.common import MarkdownDataContract
 from wurzel.executors.backend import Backend
 from wurzel.executors.backend.backend_dvc import DvcBackend
+from wurzel.executors.runtime_context import WURZEL_RUN_ID_ENV, WURZEL_WORKFLOW_NAME_ENV, WurzelRuntimeContext
 from wurzel.utils import HAS_HERA
 
 if HAS_HERA:
@@ -33,14 +34,14 @@ class TestBackendRunId:
     def test_backend_run_id_reads_from_environment(self, monkeypatch):
         """Test that run_id property reads from WURZEL_RUN_ID environment variable."""
         test_run_id = "test-run-12345"
-        monkeypatch.setenv("WURZEL_RUN_ID", test_run_id)
+        monkeypatch.setenv(WURZEL_RUN_ID_ENV, test_run_id)
 
         backend = Backend()
         assert backend.run_id == test_run_id
 
     def test_backend_run_id_returns_empty_when_not_set(self, monkeypatch):
         """Test that run_id returns empty string when WURZEL_RUN_ID is not set."""
-        monkeypatch.delenv("WURZEL_RUN_ID", raising=False)
+        monkeypatch.delenv(WURZEL_RUN_ID_ENV, raising=False)
 
         backend = Backend()
         assert backend.run_id == ""
@@ -49,11 +50,47 @@ class TestBackendRunId:
         """Test that run_id reflects changes to environment variable."""
         backend = Backend()
 
-        monkeypatch.setenv("WURZEL_RUN_ID", "run-1")
+        monkeypatch.setenv(WURZEL_RUN_ID_ENV, "run-1")
         assert backend.run_id == "run-1"
 
-        monkeypatch.setenv("WURZEL_RUN_ID", "run-2")
+        monkeypatch.setenv(WURZEL_RUN_ID_ENV, "run-2")
         assert backend.run_id == "run-2"
+
+    def test_backend_workflow_name_reads_from_environment(self, monkeypatch):
+        """Test that workflow_name reads from WURZEL_WORKFLOW_NAME."""
+        monkeypatch.setenv(WURZEL_WORKFLOW_NAME_ENV, "test-pipeline")
+
+        backend = Backend()
+        assert backend.workflow_name == "test-pipeline"
+
+    def test_backend_workflow_name_returns_empty_when_not_set(self, monkeypatch):
+        """Test that workflow_name returns empty string when WURZEL_WORKFLOW_NAME is not set."""
+        monkeypatch.delenv(WURZEL_WORKFLOW_NAME_ENV, raising=False)
+
+        backend = Backend()
+        assert backend.workflow_name == ""
+
+
+class TestWurzelRuntimeContext:
+    def test_runtime_context_reads_wurzel_owned_environment(self, monkeypatch):
+        """Test that runtime context reads only Wurzel-owned environment keys."""
+        monkeypatch.setenv(WURZEL_RUN_ID_ENV, "run-123")
+        monkeypatch.setenv(WURZEL_WORKFLOW_NAME_ENV, "pipeline-dev")
+
+        context = WurzelRuntimeContext.from_env()
+
+        assert context.run_id == "run-123"
+        assert context.workflow_name == "pipeline-dev"
+        assert context.metric_labels() == {"run_id": "run-123", "workflow_name": "pipeline-dev"}
+
+    def test_runtime_context_defaults_to_unknown(self, monkeypatch):
+        """Test missing Wurzel runtime context values use unknown."""
+        monkeypatch.delenv(WURZEL_RUN_ID_ENV, raising=False)
+        monkeypatch.delenv(WURZEL_WORKFLOW_NAME_ENV, raising=False)
+
+        context = WurzelRuntimeContext.from_env()
+
+        assert context.metric_labels() == {"run_id": "unknown", "workflow_name": "unknown"}
 
 
 class TestDvcBackendRunId:
@@ -81,6 +118,15 @@ class TestDvcBackendRunId:
         assert "generate_run_id:" in yaml_output
         assert "WURZEL_RUN_ID=" in yaml_output
         assert "dvc-$(date" in yaml_output
+
+    def test_dvc_generated_artifact_includes_wurzel_workflow_name(self):
+        """Test that DVC generated artifacts include backend-neutral workflow name."""
+        backend = DvcBackend(workflow_name="dvc-pipeline")
+        step = DummyStep()
+
+        yaml_output = backend.generate_artifact(step)
+
+        assert "WURZEL_WORKFLOW_NAME=dvc-pipeline" in yaml_output
 
     def test_dvc_run_id_uses_timestamp_fallback(self):
         """Test that DVC uses timestamp-based fallback for run_id."""
@@ -126,6 +172,22 @@ class TestDvcBackendRunId:
             deps = stages[stage_name].get("deps", [])
             assert any(str(dep).endswith(run_id_filename) for dep in deps)
 
+    def test_dvc_from_values_uses_pipeline_name_as_workflow_context(self, tmp_path):
+        """Test that DVC values selection populates the Wurzel workflow context."""
+        values_file = tmp_path / "dvc-values.yaml"
+        values_file.write_text(
+            """
+dvc:
+  selected-pipeline:
+    dataDir: ./selected-data
+""",
+            encoding="utf-8",
+        )
+
+        backend = DvcBackend.from_values([values_file], workflow_name="selected-pipeline")
+
+        assert backend.workflow_context_name == "selected-pipeline"
+
 
 @pytest.mark.skipif(not HAS_HERA, reason="Hera not available")
 class TestArgoBackendRunId:
@@ -153,8 +215,18 @@ class TestArgoBackendRunId:
         assert "WURZEL_RUN_ID" in yaml_output
         assert "{{workflow.uid}}" in yaml_output
 
+    def test_argo_generated_artifact_includes_workflow_name_context(self):
+        """Test that Argo generated artifacts include workflow.name as Wurzel context."""
+        backend = ArgoBackend()
+        step = DummyStep()
+
+        yaml_output = backend.generate_artifact(step)
+
+        assert "WURZEL_WORKFLOW_NAME" in yaml_output
+        assert "{{workflow.name}}" in yaml_output
+
     def test_argo_run_id_in_environment_variables(self):
-        """Test that WURZEL_RUN_ID is set as an environment variable in Argo tasks."""
+        """Test that Wurzel runtime context is set in Argo task environment variables."""
         backend = ArgoBackend()
         step = DummyStep()
 
@@ -163,6 +235,8 @@ class TestArgoBackendRunId:
         # Verify the environment variable is properly set
         assert "name: WURZEL_RUN_ID" in yaml_output or "name: 'WURZEL_RUN_ID'" in yaml_output
         assert "value: '{{workflow.uid}}'" in yaml_output or 'value: "{{workflow.uid}}"' in yaml_output
+        assert "name: WURZEL_WORKFLOW_NAME" in yaml_output or "name: 'WURZEL_WORKFLOW_NAME'" in yaml_output
+        assert "value: '{{workflow.name}}'" in yaml_output or 'value: "{{workflow.name}}"' in yaml_output
 
     def test_argo_run_id_in_all_tasks(self):
         """Test that WURZEL_RUN_ID is set for all tasks in a multi-step pipeline."""
@@ -185,6 +259,8 @@ class TestArgoBackendRunId:
         # Count occurrences of WURZEL_RUN_ID in the output
         run_id_count = yaml_output.count("WURZEL_RUN_ID")
         assert run_id_count >= 2  # Should appear for both tasks
+        workflow_name_count = yaml_output.count("WURZEL_WORKFLOW_NAME")
+        assert workflow_name_count >= 2  # Should appear for both tasks
 
 
 class TestRunIdUseCases:

--- a/tests/backend/test_backend_run_id.py
+++ b/tests/backend/test_backend_run_id.py
@@ -11,7 +11,7 @@ from wurzel.core import NoSettings, TypedStep
 from wurzel.datacontract.common import MarkdownDataContract
 from wurzel.executors.backend import Backend
 from wurzel.executors.backend.backend_dvc import DvcBackend
-from wurzel.executors.runtime_context import WURZEL_RUN_ID_ENV, WURZEL_WORKFLOW_NAME_ENV, WurzelRuntimeContext
+from wurzel.executors.runtime_context import WURZEL_RUN_ID_ENV, WurzelRuntimeContext
 from wurzel.utils import HAS_HERA
 
 if HAS_HERA:
@@ -56,41 +56,24 @@ class TestBackendRunId:
         monkeypatch.setenv(WURZEL_RUN_ID_ENV, "run-2")
         assert backend.run_id == "run-2"
 
-    def test_backend_workflow_name_reads_from_environment(self, monkeypatch):
-        """Test that workflow_name reads from WURZEL_WORKFLOW_NAME."""
-        monkeypatch.setenv(WURZEL_WORKFLOW_NAME_ENV, "test-pipeline")
-
-        backend = Backend()
-        assert backend.workflow_name == "test-pipeline"
-
-    def test_backend_workflow_name_returns_empty_when_not_set(self, monkeypatch):
-        """Test that workflow_name returns empty string when WURZEL_WORKFLOW_NAME is not set."""
-        monkeypatch.delenv(WURZEL_WORKFLOW_NAME_ENV, raising=False)
-
-        backend = Backend()
-        assert backend.workflow_name == ""
-
 
 class TestWurzelRuntimeContext:
     def test_runtime_context_reads_wurzel_owned_environment(self, monkeypatch):
         """Test that runtime context reads only Wurzel-owned environment keys."""
         monkeypatch.setenv(WURZEL_RUN_ID_ENV, "run-123")
-        monkeypatch.setenv(WURZEL_WORKFLOW_NAME_ENV, "pipeline-dev")
 
         context = WurzelRuntimeContext.from_env()
 
         assert context.run_id == "run-123"
-        assert context.workflow_name == "pipeline-dev"
-        assert context.metric_labels() == {"run_id": "run-123", "workflow_name": "pipeline-dev"}
+        assert context.metric_labels() == {"run_id": "run-123"}
 
     def test_runtime_context_defaults_to_unknown(self, monkeypatch):
         """Test missing Wurzel runtime context values use unknown."""
         monkeypatch.delenv(WURZEL_RUN_ID_ENV, raising=False)
-        monkeypatch.delenv(WURZEL_WORKFLOW_NAME_ENV, raising=False)
 
         context = WurzelRuntimeContext.from_env()
 
-        assert context.metric_labels() == {"run_id": "unknown", "workflow_name": "unknown"}
+        assert context.metric_labels() == {"run_id": "unknown"}
 
 
 class TestDvcBackendRunId:
@@ -118,15 +101,6 @@ class TestDvcBackendRunId:
         assert "generate_run_id:" in yaml_output
         assert "WURZEL_RUN_ID=" in yaml_output
         assert "dvc-$(date" in yaml_output
-
-    def test_dvc_generated_artifact_includes_wurzel_workflow_name(self):
-        """Test that DVC generated artifacts include backend-neutral workflow name."""
-        backend = DvcBackend(workflow_name="dvc-pipeline")
-        step = DummyStep()
-
-        yaml_output = backend.generate_artifact(step)
-
-        assert "WURZEL_WORKFLOW_NAME=dvc-pipeline" in yaml_output
 
     def test_dvc_run_id_uses_timestamp_fallback(self):
         """Test that DVC uses timestamp-based fallback for run_id."""
@@ -172,22 +146,6 @@ class TestDvcBackendRunId:
             deps = stages[stage_name].get("deps", [])
             assert any(str(dep).endswith(run_id_filename) for dep in deps)
 
-    def test_dvc_from_values_uses_pipeline_name_as_workflow_context(self, tmp_path):
-        """Test that DVC values selection populates the Wurzel workflow context."""
-        values_file = tmp_path / "dvc-values.yaml"
-        values_file.write_text(
-            """
-dvc:
-  selected-pipeline:
-    dataDir: ./selected-data
-""",
-            encoding="utf-8",
-        )
-
-        backend = DvcBackend.from_values([values_file], workflow_name="selected-pipeline")
-
-        assert backend.workflow_context_name == "selected-pipeline"
-
 
 @pytest.mark.skipif(not HAS_HERA, reason="Hera not available")
 class TestArgoBackendRunId:
@@ -215,16 +173,6 @@ class TestArgoBackendRunId:
         assert "WURZEL_RUN_ID" in yaml_output
         assert "{{workflow.uid}}" in yaml_output
 
-    def test_argo_generated_artifact_includes_workflow_name_context(self):
-        """Test that Argo generated artifacts include workflow.name as Wurzel context."""
-        backend = ArgoBackend()
-        step = DummyStep()
-
-        yaml_output = backend.generate_artifact(step)
-
-        assert "WURZEL_WORKFLOW_NAME" in yaml_output
-        assert "{{workflow.name}}" in yaml_output
-
     def test_argo_run_id_in_environment_variables(self):
         """Test that Wurzel runtime context is set in Argo task environment variables."""
         backend = ArgoBackend()
@@ -235,8 +183,6 @@ class TestArgoBackendRunId:
         # Verify the environment variable is properly set
         assert "name: WURZEL_RUN_ID" in yaml_output or "name: 'WURZEL_RUN_ID'" in yaml_output
         assert "value: '{{workflow.uid}}'" in yaml_output or 'value: "{{workflow.uid}}"' in yaml_output
-        assert "name: WURZEL_WORKFLOW_NAME" in yaml_output or "name: 'WURZEL_WORKFLOW_NAME'" in yaml_output
-        assert "value: '{{workflow.name}}'" in yaml_output or 'value: "{{workflow.name}}"' in yaml_output
 
     def test_argo_run_id_in_all_tasks(self):
         """Test that WURZEL_RUN_ID is set for all tasks in a multi-step pipeline."""
@@ -259,8 +205,6 @@ class TestArgoBackendRunId:
         # Count occurrences of WURZEL_RUN_ID in the output
         run_id_count = yaml_output.count("WURZEL_RUN_ID")
         assert run_id_count >= 2  # Should appear for both tasks
-        workflow_name_count = yaml_output.count("WURZEL_WORKFLOW_NAME")
-        assert workflow_name_count >= 2  # Should appear for both tasks
 
 
 class TestRunIdUseCases:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,12 @@ def reset_prometheus_singleton():
                 "step_hist_save",
                 "step_hist_load",
                 "step_hist_execute",
+                "wurzel_step_input_items",
+                "wurzel_step_result_items",
+                "wurzel_step_duration_seconds",
+                "wurzel_step_status",
+                "wurzel_step_timestamp_seconds",
+                "wurzel_step_info",
             ]:
                 collectors_to_remove.append(collector)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,19 +121,13 @@ def reset_prometheus_singleton():
         if hasattr(collector, "_name"):
             name = getattr(collector, "_name", "")
             if name in [
-                "steps_started",
-                "steps_failed",
-                "step_results",
-                "step_inputs",
-                "step_hist_save",
-                "step_hist_load",
-                "step_hist_execute",
                 "wurzel_step_input_items",
                 "wurzel_step_result_items",
                 "wurzel_step_duration_seconds",
                 "wurzel_step_status",
                 "wurzel_step_timestamp_seconds",
                 "wurzel_step_info",
+                "wurzel_step_datacontract_metric",
             ]:
                 collectors_to_remove.append(collector)
 

--- a/tests/middleware/test_prometheus_middleware.py
+++ b/tests/middleware/test_prometheus_middleware.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+import wurzel.executors.middlewares.prometheus.prometheus as prometheus_module
 from wurzel.executors.middlewares.prometheus import PrometheusMiddleware
 
 
@@ -16,6 +17,32 @@ class DummyReport(SimpleNamespace):
 
 class DummyStep:
     __name__ = "DummyStep"
+
+
+def _set_argo_context(monkeypatch, tmp_path) -> None:
+    namespace_file = tmp_path / "namespace"
+    namespace_file.write_text("steps-at-dev\n", encoding="utf-8")
+    monkeypatch.setattr(prometheus_module, "KUBERNETES_NAMESPACE_PATH", namespace_file)
+    monkeypatch.setenv("HOSTNAME", "steps-austria-dev-7vthq-wurzel-run-template-simplesplitterstep-1389639537")
+    monkeypatch.setenv("WURZEL_RUN_ID", "argo-run-uid")
+
+
+def _call_successfully(middleware: PrometheusMiddleware, reports: list[DummyReport]) -> None:
+    def call_next(step_cls: type, inputs: set | None, output_dir: Any | None):
+        return [(None, report) for report in reports]
+
+    middleware(call_next, DummyStep, set(), None)
+
+
+def _metric_samples(collector, sample_name: str):
+    return [sample for sample in list(collector.collect())[0].samples if sample.name == sample_name]
+
+
+def _sample_by_labels(collector, sample_name: str, **labels: str):
+    for sample in _metric_samples(collector, sample_name):
+        if all(sample.labels.get(name) == value for name, value in labels.items()):
+            return sample
+    raise AssertionError(f"No sample {sample_name} found with labels {labels}")
 
 
 def test_prometheus_middleware_happy_path() -> None:
@@ -196,3 +223,99 @@ def test_prometheus_middleware_datacontract_metrics(monkeypatch) -> None:
     ]
     assert len(matches) == 1
     assert matches[0].value == 5.0
+
+
+def test_prometheus_middleware_emits_observability_labels(monkeypatch, tmp_path) -> None:
+    _set_argo_context(monkeypatch, tmp_path)
+    report = DummyReport(results=1, inputs=2, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3)
+
+    m = PrometheusMiddleware()
+    _call_successfully(m, [report])
+
+    sample = _sample_by_labels(m.gauge_step_info, "wurzel_step_info", step_name="DummyStep")
+    assert sample.value == 1
+    assert sample.labels["run_id"] == "argo-run-uid"
+    assert sample.labels["workflow_name"] == "steps-austria-dev-7vthq"
+    assert sample.labels["workflow_namespace"] == "steps-at-dev"
+    assert sample.labels["step_pod"] == "steps-austria-dev-7vthq-wurzel-run-template-simplesplitterstep-1389639537"
+
+
+def test_prometheus_middleware_emits_input_and_result_gauges(monkeypatch, tmp_path) -> None:
+    _set_argo_context(monkeypatch, tmp_path)
+    reports = [
+        DummyReport(results=3, inputs=4, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3),
+        DummyReport(results=2, inputs=5, time_to_save=0.4, time_to_load=0.5, time_to_execute=0.6),
+    ]
+
+    m = PrometheusMiddleware()
+    _call_successfully(m, reports)
+
+    assert _sample_by_labels(m.gauge_step_input_items, "wurzel_step_input_items", step_name="DummyStep").value == 9
+    assert _sample_by_labels(m.gauge_step_result_items, "wurzel_step_result_items", step_name="DummyStep").value == 5
+
+
+def test_prometheus_middleware_emits_duration_gauges(monkeypatch, tmp_path) -> None:
+    _set_argo_context(monkeypatch, tmp_path)
+    reports = [
+        DummyReport(results=1, inputs=1, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3),
+        DummyReport(results=1, inputs=1, time_to_save=0.4, time_to_load=0.5, time_to_execute=0.6),
+    ]
+
+    m = PrometheusMiddleware()
+    _call_successfully(m, reports)
+
+    assert _sample_by_labels(m.gauge_step_duration_seconds, "wurzel_step_duration_seconds", phase="load").value == pytest.approx(0.7)
+    assert _sample_by_labels(m.gauge_step_duration_seconds, "wurzel_step_duration_seconds", phase="execute").value == pytest.approx(0.9)
+    assert _sample_by_labels(m.gauge_step_duration_seconds, "wurzel_step_duration_seconds", phase="save").value == pytest.approx(0.5)
+    assert _sample_by_labels(m.gauge_step_duration_seconds, "wurzel_step_duration_seconds", phase="total").value == pytest.approx(2.1)
+
+
+def test_prometheus_middleware_emits_success_status_and_timestamps(monkeypatch, tmp_path) -> None:
+    _set_argo_context(monkeypatch, tmp_path)
+    report = DummyReport(results=1, inputs=1, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3)
+
+    m = PrometheusMiddleware()
+    _call_successfully(m, [report])
+
+    assert _sample_by_labels(m.gauge_step_status, "wurzel_step_status", status="started").value == 0
+    assert _sample_by_labels(m.gauge_step_status, "wurzel_step_status", status="succeeded").value == 1
+    assert _sample_by_labels(m.gauge_step_status, "wurzel_step_status", status="failed").value == 0
+    started = _sample_by_labels(m.gauge_step_timestamp_seconds, "wurzel_step_timestamp_seconds", event="started").value
+    completed = _sample_by_labels(m.gauge_step_timestamp_seconds, "wurzel_step_timestamp_seconds", event="completed").value
+    assert started > 0
+    assert completed >= started
+
+
+def test_prometheus_middleware_emits_failed_status_and_timestamp(monkeypatch, tmp_path) -> None:
+    _set_argo_context(monkeypatch, tmp_path)
+
+    def call_next(step_cls: type, inputs: set | None, output_dir: Any | None):
+        raise RuntimeError("intentional failure")
+
+    m = PrometheusMiddleware()
+    with pytest.raises(RuntimeError):
+        m(call_next, DummyStep, set(), None)
+
+    assert _sample_by_labels(m.gauge_step_status, "wurzel_step_status", status="started").value == 0
+    assert _sample_by_labels(m.gauge_step_status, "wurzel_step_status", status="succeeded").value == 0
+    assert _sample_by_labels(m.gauge_step_status, "wurzel_step_status", status="failed").value == 1
+    started = _sample_by_labels(m.gauge_step_timestamp_seconds, "wurzel_step_timestamp_seconds", event="started").value
+    failed = _sample_by_labels(m.gauge_step_timestamp_seconds, "wurzel_step_timestamp_seconds", event="failed").value
+    assert started > 0
+    assert failed >= started
+
+
+def test_prometheus_middleware_observability_context_defaults_to_unknown(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("HOSTNAME", raising=False)
+    monkeypatch.delenv("WURZEL_RUN_ID", raising=False)
+    monkeypatch.setattr(prometheus_module, "KUBERNETES_NAMESPACE_PATH", tmp_path / "missing-namespace")
+    report = DummyReport(results=1, inputs=1, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3)
+
+    m = PrometheusMiddleware()
+    _call_successfully(m, [report])
+
+    sample = _sample_by_labels(m.gauge_step_info, "wurzel_step_info", step_name="DummyStep")
+    assert sample.labels["run_id"] == "unknown"
+    assert sample.labels["workflow_name"] == "unknown"
+    assert sample.labels["workflow_namespace"] == "unknown"
+    assert sample.labels["step_pod"] == "unknown"

--- a/tests/middleware/test_prometheus_middleware.py
+++ b/tests/middleware/test_prometheus_middleware.py
@@ -20,7 +20,6 @@ class DummyStep:
 
 def _set_wurzel_context(monkeypatch) -> None:
     monkeypatch.setenv("WURZEL_RUN_ID", "argo-run-uid")
-    monkeypatch.setenv("WURZEL_WORKFLOW_NAME", "steps-austria-dev")
 
 
 def _call_successfully(middleware: PrometheusMiddleware, reports: list[DummyReport]) -> list[tuple[Any, Any]]:
@@ -69,8 +68,7 @@ def test_prometheus_middleware_emits_observability_labels(monkeypatch) -> None:
     sample = _sample_by_labels(m.gauge_step_info, "wurzel_step_info", step_name="DummyStep")
     assert sample.value == 1
     assert sample.labels["run_id"] == "argo-run-uid"
-    assert sample.labels["workflow_name"] == "steps-austria-dev"
-    assert set(sample.labels) == {"step_name", "run_id", "workflow_name"}
+    assert set(sample.labels) == {"step_name", "run_id"}
 
 
 def test_prometheus_middleware_emits_input_and_result_gauges(monkeypatch) -> None:
@@ -160,13 +158,11 @@ def test_prometheus_middleware_emits_datacontract_metrics(monkeypatch) -> None:
     )
     assert sample.value == 5.0
     assert sample.labels["run_id"] == "argo-run-uid"
-    assert sample.labels["workflow_name"] == "steps-austria-dev"
-    assert set(sample.labels) == {"step_name", "run_id", "workflow_name", "metric_name"}
+    assert set(sample.labels) == {"step_name", "run_id", "metric_name"}
 
 
 def test_prometheus_middleware_context_defaults_to_unknown(monkeypatch) -> None:
     monkeypatch.delenv("WURZEL_RUN_ID", raising=False)
-    monkeypatch.delenv("WURZEL_WORKFLOW_NAME", raising=False)
     report = DummyReport(results=1, inputs=1, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3)
 
     m = PrometheusMiddleware()
@@ -174,5 +170,4 @@ def test_prometheus_middleware_context_defaults_to_unknown(monkeypatch) -> None:
 
     sample = _sample_by_labels(m.gauge_step_info, "wurzel_step_info", step_name="DummyStep")
     assert sample.labels["run_id"] == "unknown"
-    assert sample.labels["workflow_name"] == "unknown"
-    assert set(sample.labels) == {"step_name", "run_id", "workflow_name"}
+    assert set(sample.labels) == {"step_name", "run_id"}

--- a/tests/middleware/test_prometheus_middleware.py
+++ b/tests/middleware/test_prometheus_middleware.py
@@ -18,9 +18,9 @@ class DummyStep:
     __name__ = "DummyStep"
 
 
-def _set_argo_context(monkeypatch) -> None:
-    monkeypatch.setenv("HOSTNAME", "steps-austria-dev-7vthq-wurzel-run-template-simplesplitterstep-1389639537")
+def _set_wurzel_context(monkeypatch) -> None:
     monkeypatch.setenv("WURZEL_RUN_ID", "argo-run-uid")
+    monkeypatch.setenv("WURZEL_WORKFLOW_NAME", "steps-austria-dev")
 
 
 def _call_successfully(middleware: PrometheusMiddleware, reports: list[DummyReport]) -> list[tuple[Any, Any]]:
@@ -60,7 +60,7 @@ def test_prometheus_middleware_exception_path() -> None:
 
 
 def test_prometheus_middleware_emits_observability_labels(monkeypatch) -> None:
-    _set_argo_context(monkeypatch)
+    _set_wurzel_context(monkeypatch)
     report = DummyReport(results=1, inputs=2, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3)
 
     m = PrometheusMiddleware()
@@ -69,12 +69,12 @@ def test_prometheus_middleware_emits_observability_labels(monkeypatch) -> None:
     sample = _sample_by_labels(m.gauge_step_info, "wurzel_step_info", step_name="DummyStep")
     assert sample.value == 1
     assert sample.labels["run_id"] == "argo-run-uid"
-    assert sample.labels["workflow_name"] == "steps-austria-dev-7vthq"
+    assert sample.labels["workflow_name"] == "steps-austria-dev"
     assert set(sample.labels) == {"step_name", "run_id", "workflow_name"}
 
 
 def test_prometheus_middleware_emits_input_and_result_gauges(monkeypatch) -> None:
-    _set_argo_context(monkeypatch)
+    _set_wurzel_context(monkeypatch)
     reports = [
         DummyReport(results=3, inputs=4, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3),
         DummyReport(results=2, inputs=5, time_to_save=0.4, time_to_load=0.5, time_to_execute=0.6),
@@ -88,7 +88,7 @@ def test_prometheus_middleware_emits_input_and_result_gauges(monkeypatch) -> Non
 
 
 def test_prometheus_middleware_emits_duration_gauges(monkeypatch) -> None:
-    _set_argo_context(monkeypatch)
+    _set_wurzel_context(monkeypatch)
     reports = [
         DummyReport(results=1, inputs=1, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3),
         DummyReport(results=1, inputs=1, time_to_save=0.4, time_to_load=0.5, time_to_execute=0.6),
@@ -104,7 +104,7 @@ def test_prometheus_middleware_emits_duration_gauges(monkeypatch) -> None:
 
 
 def test_prometheus_middleware_emits_success_status_and_timestamps(monkeypatch) -> None:
-    _set_argo_context(monkeypatch)
+    _set_wurzel_context(monkeypatch)
     report = DummyReport(results=1, inputs=1, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3)
 
     m = PrometheusMiddleware()
@@ -120,7 +120,7 @@ def test_prometheus_middleware_emits_success_status_and_timestamps(monkeypatch) 
 
 
 def test_prometheus_middleware_emits_failed_status_and_timestamp(monkeypatch) -> None:
-    _set_argo_context(monkeypatch)
+    _set_wurzel_context(monkeypatch)
 
     def call_next(step_cls: type, inputs: set | None, output_dir: Any | None):
         raise RuntimeError("intentional failure")
@@ -139,7 +139,7 @@ def test_prometheus_middleware_emits_failed_status_and_timestamp(monkeypatch) ->
 
 
 def test_prometheus_middleware_emits_datacontract_metrics(monkeypatch) -> None:
-    _set_argo_context(monkeypatch)
+    _set_wurzel_context(monkeypatch)
     report = DummyReport(
         results=1,
         inputs=1,
@@ -160,13 +160,13 @@ def test_prometheus_middleware_emits_datacontract_metrics(monkeypatch) -> None:
     )
     assert sample.value == 5.0
     assert sample.labels["run_id"] == "argo-run-uid"
-    assert sample.labels["workflow_name"] == "steps-austria-dev-7vthq"
+    assert sample.labels["workflow_name"] == "steps-austria-dev"
     assert set(sample.labels) == {"step_name", "run_id", "workflow_name", "metric_name"}
 
 
 def test_prometheus_middleware_context_defaults_to_unknown(monkeypatch) -> None:
-    monkeypatch.delenv("HOSTNAME", raising=False)
     monkeypatch.delenv("WURZEL_RUN_ID", raising=False)
+    monkeypatch.delenv("WURZEL_WORKFLOW_NAME", raising=False)
     report = DummyReport(results=1, inputs=1, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3)
 
     m = PrometheusMiddleware()

--- a/tests/middleware/test_prometheus_middleware.py
+++ b/tests/middleware/test_prometheus_middleware.py
@@ -19,7 +19,9 @@ class DummyStep:
 
 
 def _set_wurzel_context(monkeypatch) -> None:
-    monkeypatch.setenv("WURZEL_RUN_ID", "argo-run-uid")
+    from wurzel.executors.runtime_context import WURZEL_RUN_ID_ENV
+
+    monkeypatch.setenv(WURZEL_RUN_ID_ENV, "argo-run-uid")
 
 
 def _call_successfully(middleware: PrometheusMiddleware, reports: list[DummyReport]) -> list[tuple[Any, Any]]:

--- a/tests/middleware/test_prometheus_middleware.py
+++ b/tests/middleware/test_prometheus_middleware.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import pytest
 
-import wurzel.executors.middlewares.prometheus.prometheus as prometheus_module
 from wurzel.executors.middlewares.prometheus import PrometheusMiddleware
 
 
@@ -19,19 +18,16 @@ class DummyStep:
     __name__ = "DummyStep"
 
 
-def _set_argo_context(monkeypatch, tmp_path) -> None:
-    namespace_file = tmp_path / "namespace"
-    namespace_file.write_text("steps-at-dev\n", encoding="utf-8")
-    monkeypatch.setattr(prometheus_module, "KUBERNETES_NAMESPACE_PATH", namespace_file)
+def _set_argo_context(monkeypatch) -> None:
     monkeypatch.setenv("HOSTNAME", "steps-austria-dev-7vthq-wurzel-run-template-simplesplitterstep-1389639537")
     monkeypatch.setenv("WURZEL_RUN_ID", "argo-run-uid")
 
 
-def _call_successfully(middleware: PrometheusMiddleware, reports: list[DummyReport]) -> None:
+def _call_successfully(middleware: PrometheusMiddleware, reports: list[DummyReport]) -> list[tuple[Any, Any]]:
     def call_next(step_cls: type, inputs: set | None, output_dir: Any | None):
         return [(None, report) for report in reports]
 
-    middleware(call_next, DummyStep, set(), None)
+    return middleware(call_next, DummyStep, set(), None)
 
 
 def _metric_samples(collector, sample_name: str):
@@ -46,14 +42,11 @@ def _sample_by_labels(collector, sample_name: str, **labels: str):
 
 
 def test_prometheus_middleware_happy_path() -> None:
-    # call_next returns list of (result, report)
     report = DummyReport(results=1, inputs=2, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3)
 
-    def call_next(step_cls: type, inputs: set | None, output_dir: Any | None):
-        return [(None, report)]
-
     m = PrometheusMiddleware()
-    data = m(call_next, DummyStep, set(), None)
+    data = _call_successfully(m, [report])
+
     assert data[0][1] is report
 
 
@@ -62,171 +55,12 @@ def test_prometheus_middleware_exception_path() -> None:
         raise RuntimeError("boom")
 
     m = PrometheusMiddleware()
-    try:
-        m(call_next, DummyStep, set(), None)
-        assert False, "should have raised"
-    except RuntimeError:
-        # expected
-        pass
-
-
-def test_prometheus_middleware_uses_run_id_from_environment(monkeypatch) -> None:
-    """Test that Prometheus middleware uses WURZEL_RUN_ID as a metric label."""
-    test_run_id = "test-run-12345"
-    monkeypatch.setenv("WURZEL_RUN_ID", test_run_id)
-
-    report = DummyReport(results=1, inputs=2, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3)
-
-    def call_next(step_cls: type, inputs: set | None, output_dir: Any | None):
-        return [(None, report)]
-
-    m = PrometheusMiddleware()
-    m(call_next, DummyStep, set(), None)
-
-    # Verify that metrics have the run_id label
-    # Check counter_started metric
-    metric_samples = list(m.counter_started.collect())[0].samples
-    assert any(sample.labels.get("run_id") == test_run_id for sample in metric_samples)
-
-
-def test_prometheus_middleware_run_id_defaults_to_unknown(monkeypatch) -> None:
-    """Test that run_id defaults to 'unknown' when WURZEL_RUN_ID is not set."""
-    monkeypatch.delenv("WURZEL_RUN_ID", raising=False)
-
-    report = DummyReport(results=1, inputs=2, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3)
-
-    def call_next(step_cls: type, inputs: set | None, output_dir: Any | None):
-        return [(None, report)]
-
-    m = PrometheusMiddleware()
-    m(call_next, DummyStep, set(), None)
-
-    # Verify that metrics have run_id='unknown'
-    metric_samples = list(m.counter_started.collect())[0].samples
-    assert any(sample.labels.get("run_id") == "unknown" for sample in metric_samples)
-
-
-def test_prometheus_middleware_run_id_in_all_metrics(monkeypatch) -> None:
-    """Test that run_id label is present in all metric types."""
-    test_run_id = "comprehensive-test-67890"
-    monkeypatch.setenv("WURZEL_RUN_ID", test_run_id)
-
-    report = DummyReport(results=5, inputs=3, time_to_save=0.5, time_to_load=0.3, time_to_execute=0.7)
-
-    def call_next(step_cls: type, inputs: set | None, output_dir: Any | None):
-        return [(None, report)]
-
-    m = PrometheusMiddleware()
-    m(call_next, DummyStep, set(), None)
-
-    # Check all counters
-    for counter in [m.counter_started, m.counter_results, m.counter_inputs]:
-        samples = list(counter.collect())[0].samples
-        assert any(sample.labels.get("run_id") == test_run_id for sample in samples), f"run_id not found in {counter._name}"
-
-    # Check all histograms
-    for histogram in [m.histogram_save, m.histogram_load, m.histogram_execute]:
-        samples = list(histogram.collect())[0].samples
-        assert any(sample.labels.get("run_id") == test_run_id for sample in samples), f"run_id not found in {histogram._name}"
-
-
-def test_prometheus_middleware_run_id_on_failure(monkeypatch) -> None:
-    """Test that run_id is recorded even when step execution fails."""
-    test_run_id = "failure-test-999"
-    monkeypatch.setenv("WURZEL_RUN_ID", test_run_id)
-
-    def call_next(step_cls: type, inputs: set | None, output_dir: Any | None):
-        raise RuntimeError("intentional failure")
-
-    m = PrometheusMiddleware()
-
     with pytest.raises(RuntimeError):
         m(call_next, DummyStep, set(), None)
 
-    # Verify that counter_failed has the run_id label
-    metric_samples = list(m.counter_failed.collect())[0].samples
-    assert any(sample.labels.get("run_id") == test_run_id for sample in metric_samples)
 
-
-def test_prometheus_middleware_different_run_ids_create_separate_metrics(monkeypatch) -> None:
-    """Test that different run_ids create separate metric series."""
-    report = DummyReport(results=1, inputs=1, time_to_save=0.1, time_to_load=0.1, time_to_execute=0.1)
-
-    def call_next(step_cls: type, inputs: set | None, output_dir: Any | None):
-        return [(None, report)]
-
-    m = PrometheusMiddleware()
-
-    # Execute with first run_id
-    monkeypatch.setenv("WURZEL_RUN_ID", "run-1")
-    m(call_next, DummyStep, set(), None)
-
-    # Execute with second run_id
-    monkeypatch.setenv("WURZEL_RUN_ID", "run-2")
-    m(call_next, DummyStep, set(), None)
-
-    # Verify both run_ids are present in metrics
-    metric_samples = list(m.counter_started.collect())[0].samples
-    run_ids = {sample.labels.get("run_id") for sample in metric_samples}
-    assert "run-1" in run_ids
-    assert "run-2" in run_ids
-
-
-def test_prometheus_middleware_run_id_with_step_name_label(monkeypatch) -> None:
-    """Test that run_id and step_name labels work together."""
-    test_run_id = "label-combo-test"
-    monkeypatch.setenv("WURZEL_RUN_ID", test_run_id)
-
-    report = DummyReport(results=1, inputs=1, time_to_save=0.1, time_to_load=0.1, time_to_execute=0.1)
-
-    def call_next(step_cls: type, inputs: set | None, output_dir: Any | None):
-        return [(None, report)]
-
-    m = PrometheusMiddleware()
-    m(call_next, DummyStep, set(), None)
-
-    # Verify both labels are present
-    metric_samples = list(m.counter_started.collect())[0].samples
-    matching_samples = [
-        sample for sample in metric_samples if sample.labels.get("run_id") == test_run_id and sample.labels.get("step_name") == "DummyStep"
-    ]
-    assert len(matching_samples) > 0, "Expected to find metrics with both run_id and step_name labels"
-
-
-def test_prometheus_middleware_datacontract_metrics(monkeypatch) -> None:
-    test_run_id = "metrics-test-123"
-    monkeypatch.setenv("WURZEL_RUN_ID", test_run_id)
-
-    report = DummyReport(
-        results=1,
-        inputs=1,
-        time_to_save=0.1,
-        time_to_load=0.1,
-        time_to_execute=0.1,
-        metrics={"md_char_len": 5.0},
-    )
-
-    def call_next(step_cls: type, inputs: set | None, output_dir: Any | None):
-        return [(None, report)]
-
-    m = PrometheusMiddleware()
-    m(call_next, DummyStep, set(), None)
-
-    metric_samples = list(m.gauge_contract_metrics.collect())[0].samples
-    matches = [
-        sample
-        for sample in metric_samples
-        if sample.name == "step_datacontract_metric"
-        and sample.labels.get("metric_name") == "md_char_len"
-        and sample.labels.get("step_name") == "DummyStep"
-        and sample.labels.get("run_id") == test_run_id
-    ]
-    assert len(matches) == 1
-    assert matches[0].value == 5.0
-
-
-def test_prometheus_middleware_emits_observability_labels(monkeypatch, tmp_path) -> None:
-    _set_argo_context(monkeypatch, tmp_path)
+def test_prometheus_middleware_emits_observability_labels(monkeypatch) -> None:
+    _set_argo_context(monkeypatch)
     report = DummyReport(results=1, inputs=2, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3)
 
     m = PrometheusMiddleware()
@@ -236,12 +70,12 @@ def test_prometheus_middleware_emits_observability_labels(monkeypatch, tmp_path)
     assert sample.value == 1
     assert sample.labels["run_id"] == "argo-run-uid"
     assert sample.labels["workflow_name"] == "steps-austria-dev-7vthq"
-    assert sample.labels["workflow_namespace"] == "steps-at-dev"
     assert sample.labels["step_pod"] == "steps-austria-dev-7vthq-wurzel-run-template-simplesplitterstep-1389639537"
+    assert "workflow_namespace" not in sample.labels
 
 
-def test_prometheus_middleware_emits_input_and_result_gauges(monkeypatch, tmp_path) -> None:
-    _set_argo_context(monkeypatch, tmp_path)
+def test_prometheus_middleware_emits_input_and_result_gauges(monkeypatch) -> None:
+    _set_argo_context(monkeypatch)
     reports = [
         DummyReport(results=3, inputs=4, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3),
         DummyReport(results=2, inputs=5, time_to_save=0.4, time_to_load=0.5, time_to_execute=0.6),
@@ -254,8 +88,8 @@ def test_prometheus_middleware_emits_input_and_result_gauges(monkeypatch, tmp_pa
     assert _sample_by_labels(m.gauge_step_result_items, "wurzel_step_result_items", step_name="DummyStep").value == 5
 
 
-def test_prometheus_middleware_emits_duration_gauges(monkeypatch, tmp_path) -> None:
-    _set_argo_context(monkeypatch, tmp_path)
+def test_prometheus_middleware_emits_duration_gauges(monkeypatch) -> None:
+    _set_argo_context(monkeypatch)
     reports = [
         DummyReport(results=1, inputs=1, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3),
         DummyReport(results=1, inputs=1, time_to_save=0.4, time_to_load=0.5, time_to_execute=0.6),
@@ -270,8 +104,8 @@ def test_prometheus_middleware_emits_duration_gauges(monkeypatch, tmp_path) -> N
     assert _sample_by_labels(m.gauge_step_duration_seconds, "wurzel_step_duration_seconds", phase="total").value == pytest.approx(2.1)
 
 
-def test_prometheus_middleware_emits_success_status_and_timestamps(monkeypatch, tmp_path) -> None:
-    _set_argo_context(monkeypatch, tmp_path)
+def test_prometheus_middleware_emits_success_status_and_timestamps(monkeypatch) -> None:
+    _set_argo_context(monkeypatch)
     report = DummyReport(results=1, inputs=1, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3)
 
     m = PrometheusMiddleware()
@@ -286,8 +120,8 @@ def test_prometheus_middleware_emits_success_status_and_timestamps(monkeypatch, 
     assert completed >= started
 
 
-def test_prometheus_middleware_emits_failed_status_and_timestamp(monkeypatch, tmp_path) -> None:
-    _set_argo_context(monkeypatch, tmp_path)
+def test_prometheus_middleware_emits_failed_status_and_timestamp(monkeypatch) -> None:
+    _set_argo_context(monkeypatch)
 
     def call_next(step_cls: type, inputs: set | None, output_dir: Any | None):
         raise RuntimeError("intentional failure")
@@ -305,10 +139,35 @@ def test_prometheus_middleware_emits_failed_status_and_timestamp(monkeypatch, tm
     assert failed >= started
 
 
-def test_prometheus_middleware_observability_context_defaults_to_unknown(monkeypatch, tmp_path) -> None:
+def test_prometheus_middleware_emits_datacontract_metrics(monkeypatch) -> None:
+    _set_argo_context(monkeypatch)
+    report = DummyReport(
+        results=1,
+        inputs=1,
+        time_to_save=0.1,
+        time_to_load=0.2,
+        time_to_execute=0.3,
+        metrics={"md_char_len": 5.0},
+    )
+
+    m = PrometheusMiddleware()
+    _call_successfully(m, [report])
+
+    sample = _sample_by_labels(
+        m.gauge_step_datacontract_metric,
+        "wurzel_step_datacontract_metric",
+        step_name="DummyStep",
+        metric_name="md_char_len",
+    )
+    assert sample.value == 5.0
+    assert sample.labels["run_id"] == "argo-run-uid"
+    assert sample.labels["workflow_name"] == "steps-austria-dev-7vthq"
+    assert sample.labels["step_pod"] == "steps-austria-dev-7vthq-wurzel-run-template-simplesplitterstep-1389639537"
+
+
+def test_prometheus_middleware_context_defaults_to_unknown(monkeypatch) -> None:
     monkeypatch.delenv("HOSTNAME", raising=False)
     monkeypatch.delenv("WURZEL_RUN_ID", raising=False)
-    monkeypatch.setattr(prometheus_module, "KUBERNETES_NAMESPACE_PATH", tmp_path / "missing-namespace")
     report = DummyReport(results=1, inputs=1, time_to_save=0.1, time_to_load=0.2, time_to_execute=0.3)
 
     m = PrometheusMiddleware()
@@ -317,5 +176,4 @@ def test_prometheus_middleware_observability_context_defaults_to_unknown(monkeyp
     sample = _sample_by_labels(m.gauge_step_info, "wurzel_step_info", step_name="DummyStep")
     assert sample.labels["run_id"] == "unknown"
     assert sample.labels["workflow_name"] == "unknown"
-    assert sample.labels["workflow_namespace"] == "unknown"
     assert sample.labels["step_pod"] == "unknown"

--- a/tests/middleware/test_prometheus_middleware.py
+++ b/tests/middleware/test_prometheus_middleware.py
@@ -70,8 +70,7 @@ def test_prometheus_middleware_emits_observability_labels(monkeypatch) -> None:
     assert sample.value == 1
     assert sample.labels["run_id"] == "argo-run-uid"
     assert sample.labels["workflow_name"] == "steps-austria-dev-7vthq"
-    assert sample.labels["step_pod"] == "steps-austria-dev-7vthq-wurzel-run-template-simplesplitterstep-1389639537"
-    assert "workflow_namespace" not in sample.labels
+    assert set(sample.labels) == {"step_name", "run_id", "workflow_name"}
 
 
 def test_prometheus_middleware_emits_input_and_result_gauges(monkeypatch) -> None:
@@ -162,7 +161,7 @@ def test_prometheus_middleware_emits_datacontract_metrics(monkeypatch) -> None:
     assert sample.value == 5.0
     assert sample.labels["run_id"] == "argo-run-uid"
     assert sample.labels["workflow_name"] == "steps-austria-dev-7vthq"
-    assert sample.labels["step_pod"] == "steps-austria-dev-7vthq-wurzel-run-template-simplesplitterstep-1389639537"
+    assert set(sample.labels) == {"step_name", "run_id", "workflow_name", "metric_name"}
 
 
 def test_prometheus_middleware_context_defaults_to_unknown(monkeypatch) -> None:
@@ -176,4 +175,4 @@ def test_prometheus_middleware_context_defaults_to_unknown(monkeypatch) -> None:
     sample = _sample_by_labels(m.gauge_step_info, "wurzel_step_info", step_name="DummyStep")
     assert sample.labels["run_id"] == "unknown"
     assert sample.labels["workflow_name"] == "unknown"
-    assert sample.labels["step_pod"] == "unknown"
+    assert set(sample.labels) == {"step_name", "run_id", "workflow_name"}

--- a/wurzel/executors/backend/backend.py
+++ b/wurzel/executors/backend/backend.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from wurzel.core.typed_step import TypedStep
 from wurzel.executors.base_executor import BaseStepExecutor
-from wurzel.executors.runtime_context import WURZEL_RUN_ID_ENV, WURZEL_WORKFLOW_NAME_ENV
+from wurzel.executors.runtime_context import WURZEL_RUN_ID_ENV
 
 if TYPE_CHECKING:  # pragma: no cover - only used for type checking
     from wurzel.executors.middlewares.base import BaseMiddleware
@@ -27,10 +27,9 @@ class Backend(BaseStepExecutor):
     framework, while also inheriting all step execution functionality from BaseStepExecutor.
 
     Backend implementations must set Wurzel-owned runtime context in their generated
-    artifacts. ``WURZEL_RUN_ID`` provides a unique identifier for each pipeline run,
-    and ``WURZEL_WORKFLOW_NAME`` provides the backend-neutral workflow or pipeline name.
-    These values can be used for Prometheus labels, logging, and other runtime
-    identification needs.
+    artifacts. ``WURZEL_RUN_ID`` provides a unique identifier for each pipeline run
+    that can be used for Prometheus labels, logging, and other runtime identification
+    needs.
 
     Subclasses register themselves automatically by passing ``backend_name`` as a class
     keyword argument. Once registered, ``Backend.create("name", raw_config)`` will
@@ -149,19 +148,6 @@ class Backend(BaseStepExecutor):
 
         """
         return os.environ.get(WURZEL_RUN_ID_ENV, "")
-
-    @property
-    def workflow_name(self) -> str:
-        """Get the backend-neutral workflow or pipeline name for the current execution.
-
-        This value is set by the backend via the WURZEL_WORKFLOW_NAME environment
-        variable.
-
-        Returns:
-            str: The workflow or pipeline name, or empty string if not set.
-
-        """
-        return os.environ.get(WURZEL_WORKFLOW_NAME_ENV, "")
 
     @classmethod
     def is_available(cls) -> bool:

--- a/wurzel/executors/backend/backend.py
+++ b/wurzel/executors/backend/backend.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from wurzel.core.typed_step import TypedStep
 from wurzel.executors.base_executor import BaseStepExecutor
+from wurzel.executors.runtime_context import WURZEL_RUN_ID_ENV, WURZEL_WORKFLOW_NAME_ENV
 
 if TYPE_CHECKING:  # pragma: no cover - only used for type checking
     from wurzel.executors.middlewares.base import BaseMiddleware
@@ -25,10 +26,11 @@ class Backend(BaseStepExecutor):
     method to convert a `TypedStep` into the appropriate format required by the target
     framework, while also inheriting all step execution functionality from BaseStepExecutor.
 
-    The backend implementations must set the ``WURZEL_RUN_ID`` environment variable in their
-    generated artifacts. This provides a unique identifier for each pipeline run that can
-    be used for Prometheus job names, logging, and other runtime identification needs.
-    For Argo Workflows, this should be set to ``{{workflow.uid}}``.
+    Backend implementations must set Wurzel-owned runtime context in their generated
+    artifacts. ``WURZEL_RUN_ID`` provides a unique identifier for each pipeline run,
+    and ``WURZEL_WORKFLOW_NAME`` provides the backend-neutral workflow or pipeline name.
+    These values can be used for Prometheus labels, logging, and other runtime
+    identification needs.
 
     Subclasses register themselves automatically by passing ``backend_name`` as a class
     keyword argument. Once registered, ``Backend.create("name", raw_config)`` will
@@ -139,15 +141,27 @@ class Backend(BaseStepExecutor):
     def run_id(self) -> str:
         """Get the unique run ID for the current pipeline execution.
 
-        This ID is set by the workflow orchestrator via the WURZEL_RUN_ID environment variable.
-        For Argo Workflows, this is typically the workflow.uid.
+        This ID is set by the backend via the WURZEL_RUN_ID environment variable.
         For DVC, this is generated at pipeline execution time.
 
         Returns:
             str: The unique run ID, or empty string if not set.
 
         """
-        return os.environ.get("WURZEL_RUN_ID", "")
+        return os.environ.get(WURZEL_RUN_ID_ENV, "")
+
+    @property
+    def workflow_name(self) -> str:
+        """Get the backend-neutral workflow or pipeline name for the current execution.
+
+        This value is set by the backend via the WURZEL_WORKFLOW_NAME environment
+        variable.
+
+        Returns:
+            str: The workflow or pipeline name, or empty string if not set.
+
+        """
+        return os.environ.get(WURZEL_WORKFLOW_NAME_ENV, "")
 
     @classmethod
     def is_available(cls) -> bool:

--- a/wurzel/executors/backend/backend_argo.py
+++ b/wurzel/executors/backend/backend_argo.py
@@ -46,7 +46,7 @@ from wurzel.core import TypedStep
 from wurzel.executors.backend.backend import Backend
 from wurzel.executors.backend.values import load_values
 from wurzel.executors.base_executor import BaseStepExecutor
-from wurzel.executors.runtime_context import WURZEL_RUN_ID_ENV, WURZEL_WORKFLOW_NAME_ENV
+from wurzel.executors.runtime_context import WURZEL_RUN_ID_ENV
 
 if TYPE_CHECKING:
     from wurzel.executors.middlewares.base import BaseMiddleware
@@ -544,7 +544,6 @@ class ArgoBackend(Backend, backend_name="argo"):
 
         # Add Wurzel runtime context for tracking pipeline runs.
         env_var_list.append(EnvVar(name=WURZEL_RUN_ID_ENV, value="{{workflow.uid}}"))
-        env_var_list.append(EnvVar(name=WURZEL_WORKFLOW_NAME_ENV, value="{{workflow.name}}"))
 
         # Add HF_HOME env var if tokenizer cache is enabled
         tokenizer_cache = self.config.container.tokenizerCache

--- a/wurzel/executors/backend/backend_argo.py
+++ b/wurzel/executors/backend/backend_argo.py
@@ -46,6 +46,7 @@ from wurzel.core import TypedStep
 from wurzel.executors.backend.backend import Backend
 from wurzel.executors.backend.values import load_values
 from wurzel.executors.base_executor import BaseStepExecutor
+from wurzel.executors.runtime_context import WURZEL_RUN_ID_ENV, WURZEL_WORKFLOW_NAME_ENV
 
 if TYPE_CHECKING:
     from wurzel.executors.middlewares.base import BaseMiddleware
@@ -541,8 +542,9 @@ class ArgoBackend(Backend, backend_name="argo"):
         merged_env = {**manifest_env_vars, **self.config.container.env}  # container.env wins
         env_var_list = [EnvVar(name=name, value=str(value)) for name, value in merged_env.items()]
 
-        # Add WURZEL_RUN_ID for tracking pipeline runs
-        env_var_list.append(EnvVar(name="WURZEL_RUN_ID", value="{{workflow.uid}}"))
+        # Add Wurzel runtime context for tracking pipeline runs.
+        env_var_list.append(EnvVar(name=WURZEL_RUN_ID_ENV, value="{{workflow.uid}}"))
+        env_var_list.append(EnvVar(name=WURZEL_WORKFLOW_NAME_ENV, value="{{workflow.name}}"))
 
         # Add HF_HOME env var if tokenizer cache is enabled
         tokenizer_cache = self.config.container.tokenizerCache

--- a/wurzel/executors/backend/backend_dvc.py
+++ b/wurzel/executors/backend/backend_dvc.py
@@ -19,7 +19,7 @@ from wurzel.core import TypedStep
 from wurzel.executors.backend.backend import Backend
 from wurzel.executors.backend.values import load_values
 from wurzel.executors.base_executor import BaseStepExecutor
-from wurzel.executors.runtime_context import WURZEL_RUN_ID_ENV, WURZEL_WORKFLOW_NAME_ENV
+from wurzel.executors.runtime_context import WURZEL_RUN_ID_ENV
 
 if TYPE_CHECKING:
     from wurzel.executors.middlewares.base import BaseMiddleware
@@ -87,15 +87,6 @@ def select_pipeline(values: DvcTemplateValues, pipeline_name: str | None) -> Dvc
     return DvcConfig()
 
 
-def select_pipeline_context_name(values: DvcTemplateValues, pipeline_name: str | None) -> str:
-    """Select the backend-neutral context name for a DVC pipeline."""
-    if pipeline_name:
-        return pipeline_name
-    if values.dvc:
-        return next(iter(values.dvc))
-    return "dvc"
-
-
 class DvcBackend(Backend, backend_name="dvc"):
     """DVC-specific backend implementation for the Wurzel abstraction layer.
 
@@ -136,7 +127,6 @@ class DvcBackend(Backend, backend_name="dvc"):
         dont_encapsulate: bool = False,
         middlewares: list[str] | list["BaseMiddleware"] | None = None,
         load_middlewares_from_env: bool = False,
-        workflow_name: str = "dvc",
     ) -> None:
         """Initialize DvcBackend.
 
@@ -159,7 +149,6 @@ class DvcBackend(Backend, backend_name="dvc"):
             dataDir=self.settings.DATA_DIR,
             encapsulateEnv=self.settings.ENCAPSULATE_ENV,
         )
-        self.workflow_context_name = workflow_name or "dvc"
 
     @classmethod
     def from_values(
@@ -172,10 +161,9 @@ class DvcBackend(Backend, backend_name="dvc"):
         """Instantiate the backend from values files."""
         values = load_values(files, DvcTemplateValues)
         config = select_pipeline(values, workflow_name)
-        workflow_context_name = select_pipeline_context_name(values, workflow_name)
         if executor is not None:
-            return cls(config=config, executor=executor, workflow_name=workflow_context_name)
-        return cls(config=config, workflow_name=workflow_context_name)
+            return cls(config=config, executor=executor)
+        return cls(config=config)
 
     def _write_env_file(self, env_vars: dict[str, str]) -> Path:
         """Write env vars to {dataDir}/.wurzel_env as shell exports and return the path."""
@@ -236,7 +224,6 @@ class DvcBackend(Backend, backend_name="dvc"):
             deps_with_run_id = [*deps_with_run_id, env_file]
         cmd = (
             f'{env_source}export {WURZEL_RUN_ID_ENV}="$(cat {shlex.quote(str(run_id_output))})" '
-            f"&& export {WURZEL_WORKFLOW_NAME_ENV}={shlex.quote(self.workflow_context_name)} "
             f'&& echo "${WURZEL_RUN_ID_ENV}" &&  {cli_call}'
         )
 

--- a/wurzel/executors/backend/backend_dvc.py
+++ b/wurzel/executors/backend/backend_dvc.py
@@ -19,6 +19,7 @@ from wurzel.core import TypedStep
 from wurzel.executors.backend.backend import Backend
 from wurzel.executors.backend.values import load_values
 from wurzel.executors.base_executor import BaseStepExecutor
+from wurzel.executors.runtime_context import WURZEL_RUN_ID_ENV, WURZEL_WORKFLOW_NAME_ENV
 
 if TYPE_CHECKING:
     from wurzel.executors.middlewares.base import BaseMiddleware
@@ -86,6 +87,15 @@ def select_pipeline(values: DvcTemplateValues, pipeline_name: str | None) -> Dvc
     return DvcConfig()
 
 
+def select_pipeline_context_name(values: DvcTemplateValues, pipeline_name: str | None) -> str:
+    """Select the backend-neutral context name for a DVC pipeline."""
+    if pipeline_name:
+        return pipeline_name
+    if values.dvc:
+        return next(iter(values.dvc))
+    return "dvc"
+
+
 class DvcBackend(Backend, backend_name="dvc"):
     """DVC-specific backend implementation for the Wurzel abstraction layer.
 
@@ -126,6 +136,7 @@ class DvcBackend(Backend, backend_name="dvc"):
         dont_encapsulate: bool = False,
         middlewares: list[str] | list["BaseMiddleware"] | None = None,
         load_middlewares_from_env: bool = False,
+        workflow_name: str = "dvc",
     ) -> None:
         """Initialize DvcBackend.
 
@@ -148,6 +159,7 @@ class DvcBackend(Backend, backend_name="dvc"):
             dataDir=self.settings.DATA_DIR,
             encapsulateEnv=self.settings.ENCAPSULATE_ENV,
         )
+        self.workflow_context_name = workflow_name or "dvc"
 
     @classmethod
     def from_values(
@@ -160,9 +172,10 @@ class DvcBackend(Backend, backend_name="dvc"):
         """Instantiate the backend from values files."""
         values = load_values(files, DvcTemplateValues)
         config = select_pipeline(values, workflow_name)
+        workflow_context_name = select_pipeline_context_name(values, workflow_name)
         if executor is not None:
-            return cls(config=config, executor=executor)
-        return cls(config=config)
+            return cls(config=config, executor=executor, workflow_name=workflow_context_name)
+        return cls(config=config, workflow_name=workflow_context_name)
 
     def _write_env_file(self, env_vars: dict[str, str]) -> Path:
         """Write env vars to {dataDir}/.wurzel_env as shell exports and return the path."""
@@ -221,7 +234,11 @@ class DvcBackend(Backend, backend_name="dvc"):
         env_source = f". {shlex.quote(str(env_file))} && " if env_file else ""
         if env_file:
             deps_with_run_id = [*deps_with_run_id, env_file]
-        cmd = f'{env_source}export WURZEL_RUN_ID="$(cat {shlex.quote(str(run_id_output))})" && echo "$WURZEL_RUN_ID" &&  {cli_call}'
+        cmd = (
+            f'{env_source}export {WURZEL_RUN_ID_ENV}="$(cat {shlex.quote(str(run_id_output))})" '
+            f"&& export {WURZEL_WORKFLOW_NAME_ENV}={shlex.quote(self.workflow_context_name)} "
+            f'&& echo "${WURZEL_RUN_ID_ENV}" &&  {cli_call}'
+        )
 
         return result | {
             step.__class__.__name__: {
@@ -252,7 +269,8 @@ class DvcBackend(Backend, backend_name="dvc"):
         # Add the run_id stage that generates WURZEL_RUN_ID
         run_id_output = self.config.dataDir / ".wurzel_run_id"
         run_id_cmd = (
-            f'export WURZEL_RUN_ID="dvc-$(date +%Y%m%d-%H%M%S)-$$" && echo "$WURZEL_RUN_ID" > {run_id_output} && export WURZEL_RUN_ID'
+            f'export {WURZEL_RUN_ID_ENV}="dvc-$(date +%Y%m%d-%H%M%S)-$$" '
+            f'&& echo "${WURZEL_RUN_ID_ENV}" > {run_id_output} && export {WURZEL_RUN_ID_ENV}'
         )
         run_id_stage = {
             "generate_run_id": {

--- a/wurzel/executors/middlewares/prometheus/prometheus.py
+++ b/wurzel/executors/middlewares/prometheus/prometheus.py
@@ -20,7 +20,7 @@ from .settings import PrometheusMiddlewareSettings
 
 log = getLogger(__name__)
 
-CONTEXT_LABELS = ("step_name", "run_id", "workflow_name", "step_pod")
+CONTEXT_LABELS = ("step_name", "run_id", "workflow_name")
 ARGO_TEMPLATE_SEPARATOR = "-wurzel-run-template-"
 
 
@@ -42,11 +42,10 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
     This middleware collects metrics about step execution including:
     - Gauges for stable per-step input, output, status, timestamp, and duration values
 
-    All metrics include four labels:
+    All metrics include three labels:
     - step_name: The name of the step being executed
     - run_id: Unique identifier for the pipeline run (from WURZEL_RUN_ID env var)
     - workflow_name: Argo workflow name derived from the pod name
-    - step_pod: Kubernetes pod name from HOSTNAME
 
     The run_id label allows grouping and filtering metrics by pipeline execution,
     making it easy to track all steps from a single run together.
@@ -117,19 +116,18 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
         )
 
     @staticmethod
-    def _derive_workflow_name(step_pod: str) -> str:
-        if ARGO_TEMPLATE_SEPARATOR not in step_pod:
+    def _derive_workflow_name(hostname: str) -> str:
+        if ARGO_TEMPLATE_SEPARATOR not in hostname:
             return "unknown"
-        workflow_name = step_pod.split(ARGO_TEMPLATE_SEPARATOR, maxsplit=1)[0]
+        workflow_name = hostname.split(ARGO_TEMPLATE_SEPARATOR, maxsplit=1)[0]
         return workflow_name or "unknown"
 
     def _context_labels(self, step_name: str) -> dict[str, str]:
-        step_pod = os.environ.get("HOSTNAME") or "unknown"
+        hostname = os.environ.get("HOSTNAME") or "unknown"
         return {
             "step_name": step_name,
             "run_id": os.environ.get("WURZEL_RUN_ID", "unknown"),
-            "workflow_name": self._derive_workflow_name(step_pod),
-            "step_pod": step_pod,
+            "workflow_name": self._derive_workflow_name(hostname),
         }
 
     def _set_step_status(self, context_labels: dict[str, str], status: str) -> None:

--- a/wurzel/executors/middlewares/prometheus/prometheus.py
+++ b/wurzel/executors/middlewares/prometheus/prometheus.py
@@ -13,6 +13,7 @@ from typing import Any
 from prometheus_client import REGISTRY, CollectorRegistry, Gauge, push_to_gateway
 
 from wurzel.core.typed_step import TypedStep
+from wurzel.executors.runtime_context import WurzelRuntimeContext
 from wurzel.path import PathToFolderWithBaseModels
 
 from ..base import BaseMiddleware, ExecuteStepCallable
@@ -21,7 +22,6 @@ from .settings import PrometheusMiddlewareSettings
 log = getLogger(__name__)
 
 CONTEXT_LABELS = ("step_name", "run_id", "workflow_name")
-ARGO_TEMPLATE_SEPARATOR = "-wurzel-run-template-"
 
 
 @dataclass
@@ -44,8 +44,8 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
 
     All metrics include three labels:
     - step_name: The name of the step being executed
-    - run_id: Unique identifier for the pipeline run (from WURZEL_RUN_ID env var)
-    - workflow_name: Argo workflow name derived from the pod name
+    - run_id: Unique identifier for the pipeline run from the Wurzel runtime context
+    - workflow_name: Workflow name from the Wurzel runtime context
 
     The run_id label allows grouping and filtering metrics by pipeline execution,
     making it easy to track all steps from a single run together.
@@ -115,20 +115,8 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
             registry=self.registry,
         )
 
-    @staticmethod
-    def _derive_workflow_name(hostname: str) -> str:
-        if ARGO_TEMPLATE_SEPARATOR not in hostname:
-            return "unknown"
-        workflow_name = hostname.split(ARGO_TEMPLATE_SEPARATOR, maxsplit=1)[0]
-        return workflow_name or "unknown"
-
     def _context_labels(self, step_name: str) -> dict[str, str]:
-        hostname = os.environ.get("HOSTNAME") or "unknown"
-        return {
-            "step_name": step_name,
-            "run_id": os.environ.get("WURZEL_RUN_ID", "unknown"),
-            "workflow_name": self._derive_workflow_name(hostname),
-        }
+        return {"step_name": step_name, **WurzelRuntimeContext.from_env().metric_labels()}
 
     def _set_step_status(self, context_labels: dict[str, str], status: str) -> None:
         for known_status in ("started", "succeeded", "failed"):

--- a/wurzel/executors/middlewares/prometheus/prometheus.py
+++ b/wurzel/executors/middlewares/prometheus/prometheus.py
@@ -21,7 +21,7 @@ from .settings import PrometheusMiddlewareSettings
 
 log = getLogger(__name__)
 
-CONTEXT_LABELS = ("step_name", "run_id", "workflow_name")
+CONTEXT_LABELS = ("step_name", "run_id")
 
 
 @dataclass
@@ -42,10 +42,9 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
     This middleware collects metrics about step execution including:
     - Gauges for stable per-step input, output, status, timestamp, and duration values
 
-    All metrics include three labels:
+    All metrics include two labels:
     - step_name: The name of the step being executed
     - run_id: Unique identifier for the pipeline run from the Wurzel runtime context
-    - workflow_name: Workflow name from the Wurzel runtime context
 
     The run_id label allows grouping and filtering metrics by pipeline execution,
     making it easy to track all steps from a single run together.

--- a/wurzel/executors/middlewares/prometheus/prometheus.py
+++ b/wurzel/executors/middlewares/prometheus/prometheus.py
@@ -8,10 +8,9 @@ import os
 import time
 from dataclasses import dataclass
 from logging import getLogger
-from pathlib import Path
 from typing import Any
 
-from prometheus_client import REGISTRY, CollectorRegistry, Counter, Gauge, Histogram, push_to_gateway
+from prometheus_client import REGISTRY, CollectorRegistry, Gauge, push_to_gateway
 
 from wurzel.core.typed_step import TypedStep
 from wurzel.path import PathToFolderWithBaseModels
@@ -21,9 +20,8 @@ from .settings import PrometheusMiddlewareSettings
 
 log = getLogger(__name__)
 
-CONTEXT_LABELS = ("step_name", "run_id", "workflow_name", "workflow_namespace", "step_pod")
+CONTEXT_LABELS = ("step_name", "run_id", "workflow_name", "step_pod")
 ARGO_TEMPLATE_SEPARATOR = "-wurzel-run-template-"
-KUBERNETES_NAMESPACE_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 
 
 @dataclass
@@ -42,16 +40,13 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
     """Middleware that adds Prometheus metrics collection to step execution.
 
     This middleware collects metrics about step execution including:
-    - Counter of steps started
-    - Counter of steps failed
-    - Counter of results produced
-    - Counter of inputs processed
-    - Histograms for load, execute, and save times
     - Gauges for stable per-step input, output, status, timestamp, and duration values
 
-    All metrics include two labels:
+    All metrics include four labels:
     - step_name: The name of the step being executed
     - run_id: Unique identifier for the pipeline run (from WURZEL_RUN_ID env var)
+    - workflow_name: Argo workflow name derived from the pod name
+    - step_pod: Kubernetes pod name from HOSTNAME
 
     The run_id label allows grouping and filtering metrics by pipeline execution,
     making it easy to track all steps from a single run together.
@@ -78,27 +73,6 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
         if self.settings.DISABLE_CREATED_METRIC:
             os.environ["PROMETHEUS_DISABLE_CREATED_SERIES"] = "True"
 
-        # Add run_id as a label to all metrics for identifying pipeline runs
-        self.counter_started = Counter(
-            "steps_started", "Total number of TypedSteps started", ("step_name", "run_id"), registry=self.registry
-        )
-        self.counter_failed = Counter("steps_failed", "Total number of TypedSteps failed", ("step_name", "run_id"), registry=self.registry)
-        self.counter_results = Counter(
-            "step_results",
-            "count of result, if its an array, otherwise -1",
-            ("step_name", "run_id"),
-            registry=self.registry,
-        )
-        self.counter_inputs = Counter("step_inputs", "count of inputs", ("step_name", "run_id"), registry=self.registry)
-        self.histogram_save = Histogram("step_hist_save", "Time to save results", ("step_name", "run_id"), registry=self.registry)
-        self.histogram_load = Histogram("step_hist_load", "Time to load inputs", ("step_name", "run_id"), registry=self.registry)
-        self.histogram_execute = Histogram("step_hist_execute", "Time to execute results", ("step_name", "run_id"), registry=self.registry)
-        self.gauge_contract_metrics = Gauge(
-            "step_datacontract_metric",
-            "Metrics reported by data contracts",
-            ("metric_name", "step_name", "run_id"),
-            registry=self.registry,
-        )
         self.gauge_step_input_items = Gauge(
             "wurzel_step_input_items",
             "Number of input items processed by a Wurzel step",
@@ -135,14 +109,12 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
             CONTEXT_LABELS,
             registry=self.registry,
         )
-
-    @staticmethod
-    def _read_workflow_namespace() -> str:
-        try:
-            namespace = KUBERNETES_NAMESPACE_PATH.read_text(encoding="utf-8").strip()
-        except OSError:
-            return "unknown"
-        return namespace or "unknown"
+        self.gauge_step_datacontract_metric = Gauge(
+            "wurzel_step_datacontract_metric",
+            "Metrics reported by data contracts for a Wurzel step",
+            (*CONTEXT_LABELS, "metric_name"),
+            registry=self.registry,
+        )
 
     @staticmethod
     def _derive_workflow_name(step_pod: str) -> str:
@@ -157,7 +129,6 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
             "step_name": step_name,
             "run_id": os.environ.get("WURZEL_RUN_ID", "unknown"),
             "workflow_name": self._derive_workflow_name(step_pod),
-            "workflow_namespace": self._read_workflow_namespace(),
             "step_pod": step_pod,
         }
 
@@ -165,15 +136,13 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
         for known_status in ("started", "succeeded", "failed"):
             self.gauge_step_status.labels(**context_labels, status=known_status).set(1 if known_status == status else 0)
 
-    def _collect_report_metrics(self, data: list[tuple[Any, Any]], step_name: str, run_id: str) -> StepMetricTotals:
+    def _collect_report_metrics(self, data: list[tuple[Any, Any]]) -> StepMetricTotals:
         total_results = 0.0
         total_inputs = 0.0
         tt_s, tt_l, tt_e = (0.0, 0.0, 0.0)
         contract_metrics: dict[str, float] = {}
 
         for _, report in data:
-            self.counter_results.labels(step_name, run_id).inc(report.results)
-            self.counter_inputs.labels(step_name, run_id).inc(report.inputs)
             total_results += report.results
             total_inputs += report.inputs
             tt_s += report.time_to_save
@@ -193,14 +162,8 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
             contract_metrics=contract_metrics,
         )
 
-    def _record_success_metrics(self, data: list[tuple[Any, Any]], step_name: str, run_id: str, context_labels: dict[str, str]) -> None:
-        totals = self._collect_report_metrics(data, step_name, run_id)
-
-        self.histogram_save.labels(step_name, run_id).observe(totals.time_to_save)
-        self.histogram_load.labels(step_name, run_id).observe(totals.time_to_load)
-        self.histogram_execute.labels(step_name, run_id).observe(totals.time_to_execute)
-        for name, value in totals.contract_metrics.items():
-            self.gauge_contract_metrics.labels(name, step_name, run_id).set(value)
+    def _record_success_metrics(self, data: list[tuple[Any, Any]], context_labels: dict[str, str]) -> None:
+        totals = self._collect_report_metrics(data)
 
         self.gauge_step_input_items.labels(**context_labels).set(totals.inputs)
         self.gauge_step_result_items.labels(**context_labels).set(totals.results)
@@ -210,6 +173,8 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
         self.gauge_step_duration_seconds.labels(**context_labels, phase="total").set(
             totals.time_to_load + totals.time_to_execute + totals.time_to_save
         )
+        for name, value in totals.contract_metrics.items():
+            self.gauge_step_datacontract_metric.labels(**context_labels, metric_name=name).set(value)
         self._set_step_status(context_labels, "succeeded")
         self.gauge_step_timestamp_seconds.labels(**context_labels, event="completed").set(time.time())
 
@@ -232,11 +197,9 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
             List of tuples containing step results and reports
         """
         step_name = step_cls.__name__
-        run_id = os.environ.get("WURZEL_RUN_ID", "unknown")
         context_labels = self._context_labels(step_name)
         started_at = time.time()
 
-        self.counter_started.labels(step_name, run_id).inc()
         self.gauge_step_info.labels(**context_labels).set(1)
         self._set_step_status(context_labels, "started")
         self.gauge_step_timestamp_seconds.labels(**context_labels, event="started").set(started_at)
@@ -244,12 +207,11 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
         try:
             data = call_next(step_cls, inputs, output_dir)
         except Exception:
-            self.counter_failed.labels(step_name, run_id).inc()
             self._set_step_status(context_labels, "failed")
             self.gauge_step_timestamp_seconds.labels(**context_labels, event="failed").set(time.time())
             raise
 
-        self._record_success_metrics(data, step_name, run_id, context_labels)
+        self._record_success_metrics(data, context_labels)
         return data
 
     def __enter__(self):

--- a/wurzel/executors/middlewares/prometheus/prometheus.py
+++ b/wurzel/executors/middlewares/prometheus/prometheus.py
@@ -5,7 +5,10 @@
 """Prometheus metrics middleware for step execution."""
 
 import os
+import time
+from dataclasses import dataclass
 from logging import getLogger
+from pathlib import Path
 from typing import Any
 
 from prometheus_client import REGISTRY, CollectorRegistry, Counter, Gauge, Histogram, push_to_gateway
@@ -18,6 +21,22 @@ from .settings import PrometheusMiddlewareSettings
 
 log = getLogger(__name__)
 
+CONTEXT_LABELS = ("step_name", "run_id", "workflow_name", "workflow_namespace", "step_pod")
+ARGO_TEMPLATE_SEPARATOR = "-wurzel-run-template-"
+KUBERNETES_NAMESPACE_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+
+
+@dataclass
+class StepMetricTotals:
+    """Aggregated metrics from one Wurzel step invocation."""
+
+    results: float
+    inputs: float
+    time_to_save: float
+    time_to_load: float
+    time_to_execute: float
+    contract_metrics: dict[str, float]
+
 
 class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance-attributes
     """Middleware that adds Prometheus metrics collection to step execution.
@@ -28,6 +47,7 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
     - Counter of results produced
     - Counter of inputs processed
     - Histograms for load, execute, and save times
+    - Gauges for stable per-step input, output, status, timestamp, and duration values
 
     All metrics include two labels:
     - step_name: The name of the step being executed
@@ -79,6 +99,119 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
             ("metric_name", "step_name", "run_id"),
             registry=self.registry,
         )
+        self.gauge_step_input_items = Gauge(
+            "wurzel_step_input_items",
+            "Number of input items processed by a Wurzel step",
+            CONTEXT_LABELS,
+            registry=self.registry,
+        )
+        self.gauge_step_result_items = Gauge(
+            "wurzel_step_result_items",
+            "Number of result items produced by a Wurzel step",
+            CONTEXT_LABELS,
+            registry=self.registry,
+        )
+        self.gauge_step_duration_seconds = Gauge(
+            "wurzel_step_duration_seconds",
+            "Duration of a Wurzel step phase in seconds",
+            (*CONTEXT_LABELS, "phase"),
+            registry=self.registry,
+        )
+        self.gauge_step_status = Gauge(
+            "wurzel_step_status",
+            "Status marker for a Wurzel step execution",
+            (*CONTEXT_LABELS, "status"),
+            registry=self.registry,
+        )
+        self.gauge_step_timestamp_seconds = Gauge(
+            "wurzel_step_timestamp_seconds",
+            "Unix timestamp for Wurzel step lifecycle events",
+            (*CONTEXT_LABELS, "event"),
+            registry=self.registry,
+        )
+        self.gauge_step_info = Gauge(
+            "wurzel_step_info",
+            "Static Wurzel step execution information",
+            CONTEXT_LABELS,
+            registry=self.registry,
+        )
+
+    @staticmethod
+    def _read_workflow_namespace() -> str:
+        try:
+            namespace = KUBERNETES_NAMESPACE_PATH.read_text(encoding="utf-8").strip()
+        except OSError:
+            return "unknown"
+        return namespace or "unknown"
+
+    @staticmethod
+    def _derive_workflow_name(step_pod: str) -> str:
+        if ARGO_TEMPLATE_SEPARATOR not in step_pod:
+            return "unknown"
+        workflow_name = step_pod.split(ARGO_TEMPLATE_SEPARATOR, maxsplit=1)[0]
+        return workflow_name or "unknown"
+
+    def _context_labels(self, step_name: str) -> dict[str, str]:
+        step_pod = os.environ.get("HOSTNAME") or "unknown"
+        return {
+            "step_name": step_name,
+            "run_id": os.environ.get("WURZEL_RUN_ID", "unknown"),
+            "workflow_name": self._derive_workflow_name(step_pod),
+            "workflow_namespace": self._read_workflow_namespace(),
+            "step_pod": step_pod,
+        }
+
+    def _set_step_status(self, context_labels: dict[str, str], status: str) -> None:
+        for known_status in ("started", "succeeded", "failed"):
+            self.gauge_step_status.labels(**context_labels, status=known_status).set(1 if known_status == status else 0)
+
+    def _collect_report_metrics(self, data: list[tuple[Any, Any]], step_name: str, run_id: str) -> StepMetricTotals:
+        total_results = 0.0
+        total_inputs = 0.0
+        tt_s, tt_l, tt_e = (0.0, 0.0, 0.0)
+        contract_metrics: dict[str, float] = {}
+
+        for _, report in data:
+            self.counter_results.labels(step_name, run_id).inc(report.results)
+            self.counter_inputs.labels(step_name, run_id).inc(report.inputs)
+            total_results += report.results
+            total_inputs += report.inputs
+            tt_s += report.time_to_save
+            tt_l += report.time_to_load
+            tt_e += report.time_to_execute
+            report_metrics = getattr(report, "metrics", None)
+            if report_metrics:
+                for name, value in report_metrics.items():
+                    contract_metrics[name] = contract_metrics.get(name, 0.0) + float(value)
+
+        return StepMetricTotals(
+            results=total_results,
+            inputs=total_inputs,
+            time_to_save=tt_s,
+            time_to_load=tt_l,
+            time_to_execute=tt_e,
+            contract_metrics=contract_metrics,
+        )
+
+    def _record_success_metrics(self, data: list[tuple[Any, Any]], step_name: str, run_id: str, context_labels: dict[str, str]) -> None:
+        totals = self._collect_report_metrics(data, step_name, run_id)
+
+        self.histogram_save.labels(step_name, run_id).observe(totals.time_to_save)
+        self.histogram_load.labels(step_name, run_id).observe(totals.time_to_load)
+        self.histogram_execute.labels(step_name, run_id).observe(totals.time_to_execute)
+        for name, value in totals.contract_metrics.items():
+            self.gauge_contract_metrics.labels(name, step_name, run_id).set(value)
+
+        self.gauge_step_input_items.labels(**context_labels).set(totals.inputs)
+        self.gauge_step_result_items.labels(**context_labels).set(totals.results)
+        self.gauge_step_duration_seconds.labels(**context_labels, phase="load").set(totals.time_to_load)
+        self.gauge_step_duration_seconds.labels(**context_labels, phase="execute").set(totals.time_to_execute)
+        self.gauge_step_duration_seconds.labels(**context_labels, phase="save").set(totals.time_to_save)
+        self.gauge_step_duration_seconds.labels(**context_labels, phase="total").set(
+            totals.time_to_load + totals.time_to_execute + totals.time_to_save
+        )
+        self._set_step_status(context_labels, "succeeded")
+        self.gauge_step_timestamp_seconds.labels(**context_labels, event="completed").set(time.time())
 
     def __call__(
         self,
@@ -100,35 +233,23 @@ class PrometheusMiddleware(BaseMiddleware):  # pylint: disable=too-many-instance
         """
         step_name = step_cls.__name__
         run_id = os.environ.get("WURZEL_RUN_ID", "unknown")
+        context_labels = self._context_labels(step_name)
+        started_at = time.time()
 
         self.counter_started.labels(step_name, run_id).inc()
+        self.gauge_step_info.labels(**context_labels).set(1)
+        self._set_step_status(context_labels, "started")
+        self.gauge_step_timestamp_seconds.labels(**context_labels, event="started").set(started_at)
 
         try:
             data = call_next(step_cls, inputs, output_dir)
         except Exception:
             self.counter_failed.labels(step_name, run_id).inc()
+            self._set_step_status(context_labels, "failed")
+            self.gauge_step_timestamp_seconds.labels(**context_labels, event="failed").set(time.time())
             raise
 
-        # Aggregate metrics from all reports
-        tt_s, tt_l, tt_e = (0, 0, 0)
-        contract_metrics: dict[str, float] = {}
-        for _, report in data:
-            self.counter_results.labels(step_name, run_id).inc(report.results)
-            self.counter_inputs.labels(step_name, run_id).inc(report.inputs)
-            tt_s += report.time_to_save
-            tt_l += report.time_to_load
-            tt_e += report.time_to_execute
-            report_metrics = getattr(report, "metrics", None)
-            if report_metrics:
-                for name, value in report_metrics.items():
-                    contract_metrics[name] = contract_metrics.get(name, 0.0) + float(value)
-
-        self.histogram_save.labels(step_name, run_id).observe(tt_s)
-        self.histogram_load.labels(step_name, run_id).observe(tt_l)
-        self.histogram_execute.labels(step_name, run_id).observe(tt_e)
-        for name, value in contract_metrics.items():
-            self.gauge_contract_metrics.labels(name, step_name, run_id).set(value)
-
+        self._record_success_metrics(data, step_name, run_id, context_labels)
         return data
 
     def __enter__(self):

--- a/wurzel/executors/runtime_context.py
+++ b/wurzel/executors/runtime_context.py
@@ -9,7 +9,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 
 WURZEL_RUN_ID_ENV = "WURZEL_RUN_ID"
-WURZEL_WORKFLOW_NAME_ENV = "WURZEL_WORKFLOW_NAME"
 UNKNOWN_CONTEXT_VALUE = "unknown"
 
 
@@ -18,20 +17,15 @@ class WurzelRuntimeContext:
     """Runtime context supplied by a Wurzel backend."""
 
     run_id: str = UNKNOWN_CONTEXT_VALUE
-    workflow_name: str = UNKNOWN_CONTEXT_VALUE
 
     @classmethod
     def from_env(cls, environ: Mapping[str, str] | None = None) -> "WurzelRuntimeContext":
         """Build runtime context from Wurzel-owned environment variables."""
         env = environ if environ is not None else os.environ
-        return cls(
-            run_id=env.get(WURZEL_RUN_ID_ENV) or UNKNOWN_CONTEXT_VALUE,
-            workflow_name=env.get(WURZEL_WORKFLOW_NAME_ENV) or UNKNOWN_CONTEXT_VALUE,
-        )
+        return cls(run_id=env.get(WURZEL_RUN_ID_ENV) or UNKNOWN_CONTEXT_VALUE)
 
     def metric_labels(self) -> dict[str, str]:
         """Return labels common to Wurzel runtime metrics."""
         return {
             "run_id": self.run_id,
-            "workflow_name": self.workflow_name,
         }

--- a/wurzel/executors/runtime_context.py
+++ b/wurzel/executors/runtime_context.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG (opensource@telekom.de)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend-neutral runtime context for Wurzel executions."""
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+WURZEL_RUN_ID_ENV = "WURZEL_RUN_ID"
+WURZEL_WORKFLOW_NAME_ENV = "WURZEL_WORKFLOW_NAME"
+UNKNOWN_CONTEXT_VALUE = "unknown"
+
+
+@dataclass(frozen=True)
+class WurzelRuntimeContext:
+    """Runtime context supplied by a Wurzel backend."""
+
+    run_id: str = UNKNOWN_CONTEXT_VALUE
+    workflow_name: str = UNKNOWN_CONTEXT_VALUE
+
+    @classmethod
+    def from_env(cls, environ: Mapping[str, str] | None = None) -> "WurzelRuntimeContext":
+        """Build runtime context from Wurzel-owned environment variables."""
+        env = environ if environ is not None else os.environ
+        return cls(
+            run_id=env.get(WURZEL_RUN_ID_ENV) or UNKNOWN_CONTEXT_VALUE,
+            workflow_name=env.get(WURZEL_WORKFLOW_NAME_ENV) or UNKNOWN_CONTEXT_VALUE,
+        )
+
+    def metric_labels(self) -> dict[str, str]:
+        """Return labels common to Wurzel runtime metrics."""
+        return {
+            "run_id": self.run_id,
+            "workflow_name": self.workflow_name,
+        }


### PR DESCRIPTION
## Summary
- emit only the new `wurzel_step_*` Prometheus metrics for per-step input/output counts, durations, status, lifecycle timestamps, step info, and data-contract metrics
- keep Wurzel metric labels to `step_name` and `run_id` only
- keep runtime context backend-neutral and run-id-only via `WURZEL_RUN_ID`
- Prometheus does not read Kubernetes/Argo-specific environment such as `HOSTNAME`
- remove the legacy unprefixed `steps_*`, `step_*`, and `step_datacontract_metric` collectors from the middleware
- do not read Kubernetes namespace files in Wurzel; namespace, pod, and workflow labels are expected from Pushgateway/scrape relabeling
- document the new metric surface and runtime-context contract in the middleware and Argo backend docs

## Why
These metrics make Grafana correlation easier between Wurzel steps, Argo workflow pods, Kubernetes pod phase, CPU/memory, resource requests, and per-step input/output evolution over time while keeping the middleware backend-neutral for Argo, DVC, and future backends.

## Validation
- `.venv/bin/python -m pytest tests/middleware/test_prometheus_middleware.py tests/backend/test_backend_run_id.py`
- `.venv/bin/python -m pytest tests/backend/test_backend_dvc.py tests/backend/test_backend_argo.py tests/backend/test_backend_from_values.py`
- `.venv/bin/python -m ruff check wurzel/executors/runtime_context.py wurzel/executors/middlewares/prometheus/prometheus.py wurzel/executors/backend/backend.py wurzel/executors/backend/backend_dvc.py wurzel/executors/backend/backend_argo.py tests/middleware/test_prometheus_middleware.py tests/backend/test_backend_run_id.py`
- `git diff --check`
- pre-commit hooks during commit: reuse, ruff-format, ruff, pylint, ty