### PR TITLE
Harden Argo workflow generation for PVC and policy compliance

### DIFF
--- a/docs/backends/argoworkflows.md
+++ b/docs/backends/argoworkflows.md
@@ -262,6 +262,7 @@ argo list --label workflows.argoproj.io/cron-workflow=my-scheduled-pipeline
 | `name` | string | `wurzel` | Name of the Workflow/CronWorkflow |
 | `namespace` | string | `argo-workflows` | Kubernetes namespace |
 | `schedules` | list[string]/null | `null` | Cron schedules for CronWorkflow. Set to `null` to create a normal Workflow instead |
+| `useGenerateNameForWorkflow` | bool | `true` | For plain Workflow manifests, emit `metadata.generateName` instead of a fixed `metadata.name` to avoid name/PVC collisions across reruns |
 | `entrypoint` | string | `wurzel-pipeline` | DAG entrypoint name |
 | `serviceAccountName` | string | `wurzel-service-account` | Kubernetes service account |
 | `dataDir` | path | `/usr/app` | Data directory inside containers |
@@ -289,7 +290,7 @@ argo list --label workflows.argoproj.io/cron-workflow=my-scheduled-pipeline
 | `runAsUser` | int | `null` | UID to run as |
 | `runAsGroup` | int | `null` | GID to run as |
 | `allowPrivilegeEscalation` | bool | `false` | Allow privilege escalation |
-| `readOnlyRootFilesystem` | bool | `null` | Read-only root filesystem |
+| `readOnlyRootFilesystem` | bool | `true` | Read-only root filesystem |
 | `dropCapabilities` | list[str] | `["ALL"]` | Linux capabilities to drop |
 | `seccompProfileType` | string | `RuntimeDefault` | Seccomp profile type |
 
@@ -301,6 +302,8 @@ argo list --label workflows.argoproj.io/cron-workflow=my-scheduled-pipeline
 | `cpu_limit` | string/null | `null` | Optional CPU limit |
 | `memory_request` | string | `128Mi` | Memory request |
 | `memory_limit` | string | `512Mi` | Memory limit |
+| `ephemeral_storage_request` | string/null | `null` | Optional ephemeral-storage request (required by some policies when using emptyDir) |
+| `ephemeral_storage_limit` | string/null | `null` | Optional ephemeral-storage limit (required by some policies when using emptyDir) |
 
 #### Tokenizer Cache Options
 
@@ -326,6 +329,7 @@ When enabled, the `HF_HOME` environment variable is automatically set to the `mo
 !!! note "createPvc vs claimName"
     - **`createPvc: false`** (default): Uses an existing PVC specified by `claimName`. You must create the PVC separately.
     - **`createPvc: true`**: Creates a workflow-scoped PVC via Argo's `volumeClaimTemplates`. The PVC is created when the workflow starts and deleted when it completes. This is useful for temporary caches but **not** for persistent model storage across runs.
+    - For plain `Workflow` manifests, keep `useGenerateNameForWorkflow: true` when `createPvc: true` to avoid PVC ownerReference collisions on reruns.
 
 #### S3 Artifact Options
 

--- a/tests/backend/test_backend_argo.py
+++ b/tests/backend/test_backend_argo.py
@@ -120,7 +120,7 @@ class TestSecurityContextConfig:
         assert config.runAsGroup is None
         assert config.fsGroup is None
         assert config.allowPrivilegeEscalation is False
-        assert config.readOnlyRootFilesystem is None
+        assert config.readOnlyRootFilesystem is True
         assert config.dropCapabilities == ["ALL"]
         assert config.seccompProfileType == "RuntimeDefault"
         assert config.seccompLocalhostProfile is None
@@ -149,6 +149,8 @@ class TestResourcesConfig:
         assert config.cpu_limit is None
         assert config.memory_request == "128Mi"
         assert config.memory_limit == "512Mi"
+        assert config.ephemeral_storage_request is None
+        assert config.ephemeral_storage_limit is None
 
     def test_custom_values(self):
         config = ResourcesConfig(
@@ -156,11 +158,15 @@ class TestResourcesConfig:
             cpu_limit="1",
             memory_request="256Mi",
             memory_limit="1Gi",
+            ephemeral_storage_request="1Gi",
+            ephemeral_storage_limit="2Gi",
         )
         assert config.cpu_request == "200m"
         assert config.cpu_limit == "1"
         assert config.memory_request == "256Mi"
         assert config.memory_limit == "1Gi"
+        assert config.ephemeral_storage_request == "1Gi"
+        assert config.ephemeral_storage_limit == "2Gi"
 
 
 class TestContainerConfig:
@@ -211,6 +217,7 @@ class TestWorkflowConfig:
         assert config.name == "wurzel"
         assert config.namespace == "argo-workflows"
         assert config.schedules is None
+        assert config.useGenerateNameForWorkflow is True
         assert config.entrypoint == "wurzel-pipeline"
         assert config.dataDir == Path("/usr/app")
         assert isinstance(config.container, ContainerConfig)
@@ -229,6 +236,22 @@ class TestWorkflowConfig:
         )
         assert config.podSecurityContext.runAsUser == 1000
         assert config.podSecurityContext.fsGroup == 2000
+
+    def test_raises_on_workflow_fixed_name_with_created_tokenizer_pvc(self):
+        with pytest.raises(
+            ValueError,
+            match="tokenizerCache.createPvc=true with plain Workflow requires useGenerateNameForWorkflow=true",
+        ):
+            WorkflowConfig(
+                schedules=None,
+                useGenerateNameForWorkflow=False,
+                container=ContainerConfig(
+                    tokenizerCache=TokenizerCacheConfig(
+                        enabled=True,
+                        createPvc=True,
+                    )
+                ),
+            )
 
 
 class TestTemplateValues:
@@ -790,6 +813,7 @@ class TestArgoBackendGenerateWorkflow:
             name=workflow_name,
             namespace=namespace,
             serviceAccountName=service_account,
+            useGenerateNameForWorkflow=False,
         )
         backend = ArgoBackend(config=config)
         step = DummyStep()
@@ -810,6 +834,8 @@ class TestArgoBackendGenerateWorkflow:
 
         assert workflow.kind == "Workflow"
         assert workflow.kind != "CronWorkflow"
+        assert workflow.generate_name == "wurzel-"
+        assert workflow.name is None
 
     def test_workflow_with_schedule_is_cron(self):
         """Explicit test that schedules parameter creates a CronWorkflow."""
@@ -857,6 +883,8 @@ class TestArgoBackendGenerateWorkflow:
         else:
             assert workflow_dict["kind"] == "Workflow"
             assert "schedules" not in workflow_dict["spec"]
+            assert workflow_dict["metadata"]["generateName"] == "wurzel-"
+            assert "name" not in workflow_dict["metadata"]
 
 
 class TestArgoBackendCreateArtifactFromStep:
@@ -1219,6 +1247,36 @@ class TestArgoBackendSecurityContext:
             assert "cpu" not in resources.get("limits", {})
             assert resources.get("limits", {}).get("memory")
 
+    def test_ephemeral_storage_resources(self):
+        config = WorkflowConfig(
+            container=ContainerConfig(
+                resources=ResourcesConfig(
+                    cpu_request="100m",
+                    memory_request="256Mi",
+                    memory_limit="1Gi",
+                    ephemeral_storage_request="1Gi",
+                    ephemeral_storage_limit="2Gi",
+                )
+            )
+        )
+        backend = ArgoBackend(config=config)
+        step = DummyStep()
+        yaml_output = backend.generate_artifact(step)
+        workflow = yaml.safe_load(yaml_output)
+
+        spec = workflow.get("spec", {})
+        if "workflowSpec" in spec:
+            templates = spec["workflowSpec"].get("templates", [])
+        else:
+            templates = spec.get("templates", [])
+
+        container_templates = [t for t in templates if "container" in t]
+        assert len(container_templates) > 0
+        for template in container_templates:
+            resources = template["container"].get("resources", {})
+            assert resources.get("requests", {}).get("ephemeral-storage") == "1Gi"
+            assert resources.get("limits", {}).get("ephemeral-storage") == "2Gi"
+
     def test_default_node_selector_in_workflow(self):
         """Test that generated workflows select a Kubernetes architecture."""
         backend = ArgoBackend()
@@ -1506,7 +1564,8 @@ class TestArgoBackendWorkflowCreationCornerCases:
 
         # Verify it's a normal Workflow
         assert workflow_dict["kind"] == "Workflow"
-        assert workflow_dict["metadata"]["name"] == "test-normal-workflow"
+        assert workflow_dict["metadata"]["generateName"] == "test-normal-workflow-"
+        assert "name" not in workflow_dict["metadata"]
         assert workflow_dict["metadata"]["namespace"] == "test-ns"
 
         # Normal Workflow should NOT have schedule in spec

--- a/wurzel/executors/backend/backend_argo.py
+++ b/wurzel/executors/backend/backend_argo.py
@@ -467,44 +467,44 @@ class ArgoBackend(Backend, backend_name="argo"):
             >>> assert workflow.kind == "Workflow"
 
         """
+        namespace = self.config.namespace
+        entrypoint = self.config.entrypoint
+        annotations = self.config.annotations
+        service_account_name = self.config.serviceAccountName
+        volumes = self._volumes or None
+        pod_security_context = self._build_pod_security_context()
+        node_selector = self.config.nodeSelector or None
+        pod_spec_patch = self._build_pod_spec_patch()
+
         if self.config.schedules:
             context = CronWorkflow(
                 schedules=self.config.schedules,
                 name=self.config.name,
-                namespace=self.config.namespace,
-                entrypoint=self.config.entrypoint,
-                annotations=self.config.annotations,
-                service_account_name=self.config.serviceAccountName,
-                volumes=self._volumes or None,
-                security_context=self._build_pod_security_context(),
-                node_selector=self.config.nodeSelector or None,
-                pod_spec_patch=self._build_pod_spec_patch(),
+                namespace=namespace,
+                entrypoint=entrypoint,
+                annotations=annotations,
+                service_account_name=service_account_name,
+                volumes=volumes,
+                security_context=pod_security_context,
+                node_selector=node_selector,
+                pod_spec_patch=pod_spec_patch,
             )
         else:
+            workflow_kwargs: dict[str, Any] = {
+                "namespace": namespace,
+                "entrypoint": entrypoint,
+                "annotations": annotations,
+                "service_account_name": service_account_name,
+                "volumes": volumes,
+                "security_context": pod_security_context,
+                "node_selector": node_selector,
+                "pod_spec_patch": pod_spec_patch,
+            }
             if self.config.useGenerateNameForWorkflow:
-                context = Workflow(
-                    generate_name=f"{self.config.name}-",
-                    namespace=self.config.namespace,
-                    entrypoint=self.config.entrypoint,
-                    annotations=self.config.annotations,
-                    service_account_name=self.config.serviceAccountName,
-                    volumes=self._volumes or None,
-                    security_context=self._build_pod_security_context(),
-                    node_selector=self.config.nodeSelector or None,
-                    pod_spec_patch=self._build_pod_spec_patch(),
-                )
+                workflow_kwargs["generate_name"] = f"{self.config.name}-"
             else:
-                context = Workflow(
-                    name=self.config.name,
-                    namespace=self.config.namespace,
-                    entrypoint=self.config.entrypoint,
-                    annotations=self.config.annotations,
-                    service_account_name=self.config.serviceAccountName,
-                    volumes=self._volumes or None,
-                    security_context=self._build_pod_security_context(),
-                    node_selector=self.config.nodeSelector or None,
-                    pod_spec_patch=self._build_pod_spec_patch(),
-                )
+                workflow_kwargs["name"] = self.config.name
+            context = Workflow(**workflow_kwargs)
 
         with context as workflow:
             self.__generate_dag(step, env_vars=env_vars)

--- a/wurzel/executors/backend/backend_argo.py
+++ b/wurzel/executors/backend/backend_argo.py
@@ -106,7 +106,7 @@ class SecurityContextConfig(BaseModel):
     fsGroupChangePolicy: Literal["OnRootMismatch", "Always"] | None = None
     supplementalGroups: list[int] = Field(default_factory=list)
     allowPrivilegeEscalation: bool | None = False
-    readOnlyRootFilesystem: bool | None = None
+    readOnlyRootFilesystem: bool | None = True
     dropCapabilities: list[str] = Field(default_factory=lambda: ["ALL"])
     seccompProfileType: Literal["RuntimeDefault", "Localhost"] = "RuntimeDefault"
     seccompLocalhostProfile: str | None = None
@@ -119,6 +119,8 @@ class ResourcesConfig(BaseModel):
     cpu_limit: str | None = None
     memory_request: str = "128Mi"
     memory_limit: str = "512Mi"
+    ephemeral_storage_request: str | None = None
+    ephemeral_storage_limit: str | None = None
 
 
 class TokenizerCacheConfig(BaseModel):
@@ -177,6 +179,7 @@ class WorkflowConfig(BaseModel):
     name: str = "wurzel"
     namespace: str = "argo-workflows"
     schedules: list[str] | None = None
+    useGenerateNameForWorkflow: bool = True
     entrypoint: str = "wurzel-pipeline"
     serviceAccountName: str = "wurzel-service-account"
     dataDir: Path = Path("/usr/app")
@@ -202,6 +205,20 @@ class WorkflowConfig(BaseModel):
     def schedule(self) -> str | None:
         """Return the first configured schedule for legacy callers."""
         return self.schedules[0] if self.schedules else None
+
+    @model_validator(mode="after")
+    def validate_workflow_naming_with_created_tokenizer_pvc(self) -> WorkflowConfig:
+        """Prevent PVC ownerReference collisions for plain Workflow manifests."""
+        tokenizer_cache = self.container.tokenizerCache
+        if self.schedules:
+            return self
+        if tokenizer_cache.enabled and tokenizer_cache.createPvc and not self.useGenerateNameForWorkflow:
+            raise ValueError(
+                "tokenizerCache.createPvc=true with plain Workflow requires "
+                "useGenerateNameForWorkflow=true to avoid PVC ownerReference collisions "
+                "across reruns"
+            )
+        return self
 
 
 class TemplateValues(BaseModel):
@@ -390,6 +407,8 @@ class ArgoBackend(Backend, backend_name="argo"):
             cpu_limit=res.cpu_limit,
             memory_request=res.memory_request,
             memory_limit=res.memory_limit,
+            ephemeral_request=res.ephemeral_storage_request,
+            ephemeral_limit=res.ephemeral_storage_limit,
         )
 
     def _build_pod_spec_patch(self) -> str | None:
@@ -462,17 +481,30 @@ class ArgoBackend(Backend, backend_name="argo"):
                 pod_spec_patch=self._build_pod_spec_patch(),
             )
         else:
-            context = Workflow(
-                name=self.config.name,
-                namespace=self.config.namespace,
-                entrypoint=self.config.entrypoint,
-                annotations=self.config.annotations,
-                service_account_name=self.config.serviceAccountName,
-                volumes=self._volumes or None,
-                security_context=self._build_pod_security_context(),
-                node_selector=self.config.nodeSelector or None,
-                pod_spec_patch=self._build_pod_spec_patch(),
-            )
+            if self.config.useGenerateNameForWorkflow:
+                context = Workflow(
+                    generate_name=f"{self.config.name}-",
+                    namespace=self.config.namespace,
+                    entrypoint=self.config.entrypoint,
+                    annotations=self.config.annotations,
+                    service_account_name=self.config.serviceAccountName,
+                    volumes=self._volumes or None,
+                    security_context=self._build_pod_security_context(),
+                    node_selector=self.config.nodeSelector or None,
+                    pod_spec_patch=self._build_pod_spec_patch(),
+                )
+            else:
+                context = Workflow(
+                    name=self.config.name,
+                    namespace=self.config.namespace,
+                    entrypoint=self.config.entrypoint,
+                    annotations=self.config.annotations,
+                    service_account_name=self.config.serviceAccountName,
+                    volumes=self._volumes or None,
+                    security_context=self._build_pod_security_context(),
+                    node_selector=self.config.nodeSelector or None,
+                    pod_spec_patch=self._build_pod_spec_patch(),
+                )
 
         with context as workflow:
             self.__generate_dag(step, env_vars=env_vars)


### PR DESCRIPTION
## Summary
This PR hardens Argo manifest generation for environments with strict pod policies and repeated manual workflow reruns.

### Changes
- Default plain `Workflow` generation to `metadata.generateName` via new config flag:
  - `useGenerateNameForWorkflow` (default: `true`)
- Add ephemeral storage resource support:
  - `ephemeral_storage_request`
  - `ephemeral_storage_limit`
- Set safer default for container security context:
  - `readOnlyRootFilesystem: true`
- Add validation to prevent unsafe combination:
  - plain Workflow + `tokenizerCache.createPvc=true` + fixed name
- Update Argo backend tests and backend docs accordingly

## Validation
- `uv run pytest tests/backend/test_backend_argo.py -q`
- `uv run ruff check wurzel/executors/backend/backend_argo.py tests/backend/test_backend_argo.py`

## Motivation
Fixes repeated PVC ownerReference collisions and improves compatibility with policies requiring read-only root filesystems and ephemeral-storage resource constraints.
