### PR TITLE
feat: add ElevenLabs Knowledge Base connector step

### DIFF
--- a/tests/steps/elevenlabs/__init__.py
+++ b/tests/steps/elevenlabs/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/steps/elevenlabs/step_test.py
+++ b/tests/steps/elevenlabs/step_test.py
@@ -1,0 +1,556 @@
+# SPDX-FileCopyrightText: 2025
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ElevenLabsKnowledgeBaseStep using requests-mock for HTTP fixtures."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from wurzel.datacontract import MarkdownDataContract
+from wurzel.exceptions import StepFailed
+from wurzel.steps.elevenlabs import ElevenLabsKnowledgeBaseStep
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+BASE_URL = "https://api.elevenlabs.io"
+KB = f"{BASE_URL}/v1/convai/knowledge-base"
+KB_TEXT = f"{KB}/text"
+
+
+# ── Response shape helpers ────────────────────────────────────────────────────
+
+
+def kb_list_payload(*docs: tuple[str, str], has_more: bool = False, next_cursor: str | None = None, doc_type: str = "text") -> dict:
+    """ElevenLabs' GET /knowledge-base response shape. Documents default to type=text."""
+    return {
+        "documents": [{"id": doc_id, "name": name, "type": doc_type} for name, doc_id in docs],
+        "has_more": has_more,
+        "next_cursor": next_cursor,
+    }
+
+
+def kb_create_payload(doc_id: str, name: str = "doc") -> dict:
+    """Response from POST /knowledge-base/text."""
+    return {"id": doc_id, "name": name, "folder_path": []}
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def elevenlabs_env(env):
+    env.set("API_KEY", "test-api-key")
+    env.set("MAX_RETRIES", "1")  # no retries by default in unit tests — keeps mocks simple
+    env.set("RETRY_BACKOFF", "0")  # no sleep in unit tests
+    return env
+
+
+@pytest.fixture
+def step(elevenlabs_env):
+    s = ElevenLabsKnowledgeBaseStep()
+    yield s
+    s.finalize()
+
+
+@pytest.fixture
+def sample_doc():
+    return MarkdownDataContract(
+        md="# Test Title\n\nThis is test content.",
+        url="https://example.com/docs/test-doc",
+        keywords="test, sample",
+        metadata={"author": "tester"},
+    )
+
+
+@pytest.fixture
+def two_docs():
+    return [
+        MarkdownDataContract(md="# Doc 1", url="https://example.com/doc1", keywords=""),
+        MarkdownDataContract(md="# Doc 2", url="https://example.com/doc2", keywords=""),
+    ]
+
+
+# ── Init ──────────────────────────────────────────────────────────────────────
+
+
+class TestInit:
+    def test_init_sets_api_key_header(self, elevenlabs_env):
+        with patch("wurzel.steps.elevenlabs.step.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value = mock_session
+            step = ElevenLabsKnowledgeBaseStep()
+
+            mock_session.headers.update.assert_called_once_with({"xi-api-key": "test-api-key"})
+            step.finalize()
+
+    def test_init_skips_session_when_push_disabled(self, env):
+        env.set("PUSH_ENABLED", "false")
+        with patch("wurzel.steps.elevenlabs.step.requests.Session") as mock_session_cls:
+            step = ElevenLabsKnowledgeBaseStep()
+            mock_session_cls.assert_not_called()
+            step.finalize()
+
+    def test_init_raises_without_api_key_when_push_enabled(self, env):
+        with pytest.raises(ValueError, match="API_KEY is required"):
+            ElevenLabsKnowledgeBaseStep()
+
+    def test_init_raises_when_pruning_without_name_prefix(self, elevenlabs_env):
+        elevenlabs_env.set("PRUNE_STALE", "true")
+        with pytest.raises(ValueError, match="NAME_PREFIX is required"):
+            ElevenLabsKnowledgeBaseStep()
+
+
+# ── Empty input ───────────────────────────────────────────────────────────────
+
+
+class TestEmptyInput:
+    def test_returns_empty_list(self, step):
+        assert step.run([]) == []
+
+
+# ── Name generation ───────────────────────────────────────────────────────────
+
+
+class TestGenerateName:
+    @pytest.mark.parametrize(
+        "url, idx, expected",
+        [
+            ("https://example.com/tmcz/baze/magenta-wi-fi", 0, "tmcz/baze/magenta-wi-fi"),
+            ("https://example.com/", 0, "document_0000"),
+            ("", 3, "document_0003"),
+        ],
+    )
+    def test_generates_expected_name(self, step, url, idx, expected):
+        doc = MarkdownDataContract(md="content", url=url, keywords="")
+        assert step._generate_name(doc, idx) == expected
+
+    def test_applies_name_prefix(self, elevenlabs_env):
+        elevenlabs_env.set("NAME_PREFIX", "wurzel/")
+        step = ElevenLabsKnowledgeBaseStep()
+        doc = MarkdownDataContract(md="content", url="https://example.com/a", keywords="")
+
+        assert step._generate_name(doc, 0) == "wurzel/a"
+        step.finalize()
+
+    def test_stable_across_calls(self, step, sample_doc):
+        assert step._generate_name(sample_doc, 0) == step._generate_name(sample_doc, 0)
+
+
+# ── Create / update ────────────────────────────────────────────────────────────
+
+
+class TestCreateAndUpdate:
+    def test_new_document_created_and_passthrough(self, step, sample_doc, requests_mock):
+        requests_mock.get(KB, json=kb_list_payload())
+        requests_mock.post(KB_TEXT, json=kb_create_payload("doc-1", "docs/test-doc"))
+
+        result = step.run([sample_doc])
+
+        assert result == [sample_doc]
+        post_request = next(r for r in requests_mock.request_history if r.method == "POST")
+        assert post_request.json()["text"] == sample_doc.md
+        assert post_request.json()["name"] == "docs/test-doc"
+
+    def test_existing_document_updated_in_place(self, step, sample_doc, requests_mock):
+        name = "docs/test-doc"
+        requests_mock.get(KB, json=kb_list_payload((name, "doc-existing")))
+        requests_mock.patch(f"{KB}/doc-existing", json={})
+
+        result = step.run([sample_doc])
+
+        assert result == [sample_doc]
+        methods = [r.method for r in requests_mock.request_history]
+        assert "PATCH" in methods
+        assert "POST" not in methods
+        patch_request = next(r for r in requests_mock.request_history if r.method == "PATCH")
+        assert patch_request.json() == {"content": sample_doc.md}
+
+    def test_multiple_documents_processed(self, step, two_docs, requests_mock):
+        requests_mock.get(KB, json=kb_list_payload())
+        requests_mock.post(
+            KB_TEXT,
+            [
+                {"json": kb_create_payload("doc-1", "doc1")},
+                {"json": kb_create_payload("doc-2", "doc2")},
+            ],
+        )
+
+        result = step.run(two_docs)
+
+        assert result == two_docs
+        assert len([r for r in requests_mock.request_history if r.method == "POST"]) == 2
+
+    def test_parent_folder_id_included_when_set(self, elevenlabs_env, sample_doc, requests_mock):
+        elevenlabs_env.set("PARENT_FOLDER_ID", "folder-1")
+        step = ElevenLabsKnowledgeBaseStep()
+        requests_mock.get(KB, json=kb_list_payload())
+        requests_mock.post(KB_TEXT, json=kb_create_payload("doc-1"))
+
+        step.run([sample_doc])
+
+        post_request = next(r for r in requests_mock.request_history if r.method == "POST")
+        assert post_request.json()["parent_folder_id"] == "folder-1"
+        step.finalize()
+
+
+# ── Delete ─────────────────────────────────────────────────────────────────────
+
+
+class TestDelete:
+    def test_handles_empty_response_body(self, step, requests_mock):
+        """The real API returns an empty (non-JSON) body for DELETE; must not raise."""
+        requests_mock.delete(f"{KB}/doc-1", text="")
+
+        step._delete("doc-1")  # should not raise JSONDecodeError
+
+        assert requests_mock.last_request.qs.get("force") == ["false"]
+
+
+# ── Listing / pagination ───────────────────────────────────────────────────────
+
+
+class TestListPagination:
+    def test_follows_cursor_across_pages(self, step, sample_doc, requests_mock):
+        name = "docs/test-doc"
+        requests_mock.get(
+            KB,
+            [
+                {"json": kb_list_payload(("other", "other-1"), has_more=True, next_cursor="page-2")},
+                {"json": kb_list_payload((name, "doc-existing"))},
+            ],
+        )
+        requests_mock.patch(f"{KB}/doc-existing", json={})
+
+        result = step.run([sample_doc])
+
+        assert result == [sample_doc]
+        get_requests = [r for r in requests_mock.request_history if r.method == "GET"]
+        assert len(get_requests) == 2
+        assert get_requests[1].qs.get("cursor") == ["page-2"]
+
+    def test_does_not_use_search_param(self, elevenlabs_env, sample_doc, requests_mock):
+        """NAME_PREFIX must be applied client-side, not via the API's `search` param.
+
+        `search` is backed by search infrastructure that isn't guaranteed to
+        return every match (observed missing a document that plainly existed,
+        which caused a duplicate to be created instead of an update) - so it
+        must never be relied on for correctness here.
+        """
+        elevenlabs_env.set("NAME_PREFIX", "wurzel/")
+        step = ElevenLabsKnowledgeBaseStep()
+        requests_mock.get(KB, json=kb_list_payload())
+        requests_mock.post(KB_TEXT, json=kb_create_payload("doc-1"))
+
+        step.run([sample_doc])
+
+        get_request = next(r for r in requests_mock.request_history if r.method == "GET")
+        assert "search" not in get_request.qs
+        assert get_request.qs.get("types") == ["text"]
+        step.finalize()
+
+    def test_name_prefix_filters_client_side(self, elevenlabs_env, sample_doc, requests_mock):
+        """Out-of-prefix documents must never enter `existing` at all.
+
+        Asserted with PRUNE_STALE on: if the client-side filter were missing (i.e.
+        this code trusted the server to have already scoped the response by
+        NAME_PREFIX via `search`), an out-of-prefix document present in a raw
+        listing response - as this mock simulates - would be treated as stale
+        and deleted, silently touching documents outside this step's namespace.
+        """
+        elevenlabs_env.set("NAME_PREFIX", "wurzel/")
+        elevenlabs_env.set("PRUNE_STALE", "true")
+        step = ElevenLabsKnowledgeBaseStep()
+        name = "wurzel/docs/test-doc"
+        requests_mock.get(KB, json=kb_list_payload((name, "doc-existing"), ("unrelated/doc", "doc-other")))
+        requests_mock.patch(f"{KB}/doc-existing", json={})
+        delete_mock = requests_mock.delete(f"{KB}/doc-other", text="")
+
+        step.run([sample_doc])
+
+        methods = [r.method for r in requests_mock.request_history]
+        assert "PATCH" in methods
+        assert "POST" not in methods  # matched despite no server-side search filter
+        assert not delete_mock.called  # out-of-prefix doc is never a prune candidate
+        step.finalize()
+
+    def test_non_text_document_is_ignored_even_if_server_types_filter_leaks_it(self, step, sample_doc, requests_mock):
+        """Defense in depth: don't trust the server-side `types=text` filter alone."""
+        name = "docs/test-doc"
+        requests_mock.get(
+            KB,
+            json={
+                "documents": [
+                    {"id": "doc-existing", "name": name, "type": "text"},
+                    {"id": "doc-folder", "name": name, "type": "folder"},
+                ],
+                "has_more": False,
+                "next_cursor": None,
+            },
+        )
+        requests_mock.patch(f"{KB}/doc-existing", json={})
+
+        result = step.run([sample_doc])
+
+        assert result == [sample_doc]
+        methods = [r.method for r in requests_mock.request_history]
+        assert "PATCH" in methods
+        assert "DELETE" not in methods  # the non-text "duplicate" is never touched
+
+    def test_duplicate_name_self_heals_by_deleting_extra_copy(self, step, sample_doc, requests_mock):
+        name = "docs/test-doc"
+        requests_mock.get(KB, json=kb_list_payload((name, "doc-first"), (name, "doc-duplicate")))
+        requests_mock.patch(f"{KB}/doc-first", json={})
+        delete_mock = requests_mock.delete(f"{KB}/doc-duplicate", text="")
+
+        result = step.run([sample_doc])
+
+        assert result == [sample_doc]
+        assert delete_mock.called_once
+        methods = [r.method for r in requests_mock.request_history]
+        assert "PATCH" in methods  # kept the first-seen id and updated it
+        assert "POST" not in methods  # did not create a third copy
+
+    def test_list_failure_raises_instead_of_risking_a_duplicate(self, step, sample_doc, requests_mock):
+        """A failed listing must not fall back to "assume nothing exists" and create.
+
+        That's exactly the sequence that produced duplicate documents in practice:
+        a transient listing failure made an already-existing document look new.
+        """
+        requests_mock.get(KB, exc=requests.exceptions.ConnectionError("down"))
+        create_mock = requests_mock.post(KB_TEXT, json=kb_create_payload("doc-1"))
+
+        with pytest.raises(StepFailed, match="Could not list existing knowledge base documents"):
+            step.run([sample_doc])
+
+        assert not create_mock.called
+
+
+# ── Retry ──────────────────────────────────────────────────────────────────────
+
+
+class TestRetry:
+    def test_transient_500_on_list_is_retried_and_succeeds(self, elevenlabs_env, sample_doc, requests_mock):
+        elevenlabs_env.set("MAX_RETRIES", "2")
+        step = ElevenLabsKnowledgeBaseStep()
+        name = "docs/test-doc"
+        requests_mock.get(
+            KB,
+            [
+                {"status_code": 500, "text": "boom"},
+                {"json": kb_list_payload((name, "doc-existing"))},
+            ],
+        )
+        requests_mock.patch(f"{KB}/doc-existing", json={})
+
+        result = step.run([sample_doc])
+
+        assert result == [sample_doc]
+        get_requests = [r for r in requests_mock.request_history if r.method == "GET"]
+        assert len(get_requests) == 2
+        step.finalize()
+
+    def test_list_failure_raises_after_retries_exhausted(self, elevenlabs_env, sample_doc, requests_mock):
+        elevenlabs_env.set("MAX_RETRIES", "2")
+        step = ElevenLabsKnowledgeBaseStep()
+        requests_mock.get(KB, status_code=500, text="boom")
+
+        with pytest.raises(StepFailed, match="Could not list existing knowledge base documents"):
+            step.run([sample_doc])
+
+        get_requests = [r for r in requests_mock.request_history if r.method == "GET"]
+        assert len(get_requests) == 2  # exhausted MAX_RETRIES, then gave up
+        step.finalize()
+
+    def test_create_not_retried_on_read_timeout(self, step, sample_doc, requests_mock):
+        """A create must not be retried after a read timeout - the document may
+        already have been created server-side; retrying risks a duplicate.
+        """
+        requests_mock.get(KB, json=kb_list_payload())
+        requests_mock.post(KB_TEXT, exc=requests.exceptions.ReadTimeout("slow"))
+
+        with pytest.raises(StepFailed, match="All 1 documents failed"):
+            step.run([sample_doc])
+
+        post_requests = [r for r in requests_mock.request_history if r.method == "POST"]
+        assert len(post_requests) == 1  # not retried
+
+    def test_update_retried_on_connection_error(self, elevenlabs_env, sample_doc, requests_mock):
+        """Updates are idempotent (setting content to a known value) - safe to retry."""
+        elevenlabs_env.set("MAX_RETRIES", "2")
+        step = ElevenLabsKnowledgeBaseStep()
+        name = "docs/test-doc"
+        requests_mock.get(KB, json=kb_list_payload((name, "doc-existing")))
+        requests_mock.patch(
+            f"{KB}/doc-existing",
+            [
+                {"exc": requests.exceptions.ConnectionError("dropped")},
+                {"json": {}},
+            ],
+        )
+
+        result = step.run([sample_doc])
+
+        assert result == [sample_doc]
+        patch_requests = [r for r in requests_mock.request_history if r.method == "PATCH"]
+        assert len(patch_requests) == 2
+        step.finalize()
+
+
+# ── Prune ──────────────────────────────────────────────────────────────────────
+
+
+class TestPruneStale:
+    def test_prune_disabled_by_default_keeps_stale_document(self, step, sample_doc, requests_mock):
+        name = "docs/test-doc"
+        requests_mock.get(KB, json=kb_list_payload((name, "doc-existing"), ("stale/doc", "doc-stale")))
+        requests_mock.patch(f"{KB}/doc-existing", json={})
+        delete_mock = requests_mock.delete(f"{KB}/doc-stale", text="")
+
+        step.run([sample_doc])
+
+        assert not delete_mock.called
+
+    def test_prune_enabled_deletes_stale_document(self, elevenlabs_env, sample_doc, requests_mock, caplog):
+        elevenlabs_env.set("NAME_PREFIX", "wurzel/")
+        elevenlabs_env.set("PRUNE_STALE", "true")
+        step = ElevenLabsKnowledgeBaseStep()
+        name = "wurzel/docs/test-doc"
+        requests_mock.get(KB, json=kb_list_payload((name, "doc-existing"), ("wurzel/stale/doc", "doc-stale")))
+        requests_mock.patch(f"{KB}/doc-existing", json={})
+        requests_mock.delete(f"{KB}/doc-stale", text="")
+
+        with caplog.at_level("WARNING"):
+            step.run([sample_doc])
+
+        delete_requests = [r for r in requests_mock.request_history if r.method == "DELETE"]
+        assert len(delete_requests) == 1
+        assert delete_requests[0].qs.get("force") == ["false"]
+        # A real (empty-body) DELETE response must not be mistaken for a failed prune.
+        assert "Failed to prune" not in caplog.text
+        step.finalize()
+
+    def test_prune_force_passed_through(self, elevenlabs_env, sample_doc, requests_mock):
+        elevenlabs_env.set("NAME_PREFIX", "wurzel/")
+        elevenlabs_env.set("PRUNE_STALE", "true")
+        elevenlabs_env.set("PRUNE_FORCE", "true")
+        step = ElevenLabsKnowledgeBaseStep()
+        requests_mock.get(KB, json=kb_list_payload(("wurzel/stale/doc", "doc-stale")))
+        requests_mock.post(KB_TEXT, json=kb_create_payload("doc-1"))
+        requests_mock.delete(f"{KB}/doc-stale", text="")
+
+        step.run([sample_doc])
+
+        delete_request = next(r for r in requests_mock.request_history if r.method == "DELETE")
+        assert delete_request.qs.get("force") == ["true"]
+        step.finalize()
+
+    def test_prune_failure_does_not_raise(self, elevenlabs_env, sample_doc, requests_mock):
+        elevenlabs_env.set("NAME_PREFIX", "wurzel/")
+        elevenlabs_env.set("PRUNE_STALE", "true")
+        step = ElevenLabsKnowledgeBaseStep()
+        requests_mock.get(KB, json=kb_list_payload(("wurzel/stale/doc", "doc-stale")))
+        requests_mock.post(KB_TEXT, json=kb_create_payload("doc-1"))
+        requests_mock.delete(f"{KB}/doc-stale", exc=requests.exceptions.ConnectionError("failed"))
+
+        result = step.run([sample_doc])
+
+        assert result == [sample_doc]
+        step.finalize()
+
+    def test_prune_skipped_when_a_push_failed_this_run(self, elevenlabs_env, two_docs, requests_mock, caplog):
+        """A systemic failure this run must never also be allowed to delete real
+        content - mirrors Wonderful's own "skip prune on upload failure" behavior.
+        """
+        elevenlabs_env.set("NAME_PREFIX", "wurzel/")
+        elevenlabs_env.set("PRUNE_STALE", "true")
+        step = ElevenLabsKnowledgeBaseStep()
+        requests_mock.get(KB, json=kb_list_payload(("wurzel/stale/doc", "doc-stale")))
+        requests_mock.post(
+            KB_TEXT,
+            [
+                {"json": kb_create_payload("doc-1", "doc1")},
+                {"exc": requests.exceptions.ConnectionError("failed")},
+            ],
+        )
+        delete_mock = requests_mock.delete(f"{KB}/doc-stale", text="")
+
+        with caplog.at_level("WARNING"):
+            result = step.run(two_docs)
+
+        assert result == two_docs
+        assert not delete_mock.called
+        assert "Skipping prune" in caplog.text
+        step.finalize()
+
+
+# ── Failure scenarios ──────────────────────────────────────────────────────────
+
+
+class TestFailureScenarios:
+    def test_all_fail_raises_step_failed(self, step, sample_doc, requests_mock):
+        requests_mock.get(KB, json=kb_list_payload())
+        requests_mock.post(KB_TEXT, exc=requests.exceptions.ConnectionError("failed"))
+
+        with pytest.raises(StepFailed, match="All 1 documents failed"):
+            step.run([sample_doc])
+
+    def test_partial_failure_returns_input(self, step, two_docs, requests_mock):
+        requests_mock.get(KB, json=kb_list_payload())
+        requests_mock.post(
+            KB_TEXT,
+            [
+                {"json": kb_create_payload("doc-1", "doc1")},
+                {"exc": requests.exceptions.ConnectionError("failed")},
+            ],
+        )
+
+        result = step.run(two_docs)
+
+        assert result == two_docs
+
+
+# ── Push disabled ──────────────────────────────────────────────────────────────
+
+
+class TestPushDisabled:
+    def test_push_disabled_returns_input_without_api_calls(self, env, sample_doc, requests_mock):
+        env.set("PUSH_ENABLED", "false")
+        step = ElevenLabsKnowledgeBaseStep()
+
+        result = step.run([sample_doc])
+
+        assert result == [sample_doc]
+        assert requests_mock.request_history == []
+        step.finalize()
+
+    def test_push_disabled_with_empty_input(self, env):
+        env.set("PUSH_ENABLED", "false")
+        step = ElevenLabsKnowledgeBaseStep()
+
+        assert step.run([]) == []
+        step.finalize()
+
+
+# ── Finalize ───────────────────────────────────────────────────────────────────
+
+
+class TestFinalize:
+    def test_finalize_closes_session(self, elevenlabs_env):
+        with patch("wurzel.steps.elevenlabs.step.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value = mock_session
+
+            step = ElevenLabsKnowledgeBaseStep()
+            step.finalize()
+
+            mock_session.close.assert_called_once()
+
+    def test_finalize_no_session_when_push_disabled(self, env):
+        env.set("PUSH_ENABLED", "false")
+        with patch("wurzel.steps.elevenlabs.step.requests.Session") as mock_session_cls:
+            step = ElevenLabsKnowledgeBaseStep()
+            step.finalize()  # should not raise
+            mock_session_cls.assert_not_called()

--- a/tests/steps/elevenlabs/step_test.py
+++ b/tests/steps/elevenlabs/step_test.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
+from wurzel.core import step_history
+from wurzel.core.history import History
 from wurzel.datacontract import MarkdownDataContract
 from wurzel.exceptions import StepFailed
 from wurzel.steps.elevenlabs import ElevenLabsKnowledgeBaseStep
@@ -71,6 +73,23 @@ def two_docs():
         MarkdownDataContract(md="# Doc 1", url="https://example.com/doc1", keywords=""),
         MarkdownDataContract(md="# Doc 2", url="https://example.com/doc2", keywords=""),
     ]
+
+
+@pytest.fixture
+def history_scope():
+    """Sets step_history for the duration of a test, resetting it afterward.
+
+    step_history is a module-level ContextVar - left unset it stays None (the
+    default, matching a step run outside the wurzel Executor). Tests using this
+    fixture must reset it themselves rather than relying on test isolation,
+    since pytest runs tests sequentially in the same context.
+    """
+
+    def _set(*chain: str) -> None:
+        step_history.set(History(*chain))
+
+    yield _set
+    step_history.set(None)
 
 
 # ── Init ──────────────────────────────────────────────────────────────────────
@@ -137,6 +156,82 @@ class TestGenerateName:
 
     def test_stable_across_calls(self, step, sample_doc):
         assert step._generate_name(sample_doc, 0) == step._generate_name(sample_doc, 0)
+
+    def test_includes_history_tag_when_set(self, step, history_scope):
+        history_scope("SourceA", "ElevenLabsKnowledgeBase")
+        doc = MarkdownDataContract(md="content", url="https://example.com/a", keywords="")
+
+        assert step._generate_name(doc, 0) == "SourceA-ElevenLabsKnowledgeBase/a"
+
+    def test_no_history_tag_when_unset(self, step):
+        doc = MarkdownDataContract(md="content", url="https://example.com/a", keywords="")
+
+        assert step._generate_name(doc, 0) == "a"
+
+    def test_history_tag_combines_with_name_prefix(self, elevenlabs_env, history_scope):
+        elevenlabs_env.set("NAME_PREFIX", "wurzel/")
+        history_scope("SourceA")
+        step = ElevenLabsKnowledgeBaseStep()
+        doc = MarkdownDataContract(md="content", url="https://example.com/a", keywords="")
+
+        assert step._generate_name(doc, 0) == "wurzel/SourceA/a"
+        step.finalize()
+
+
+# ── History-scoped isolation ────────────────────────────────────────────────────
+
+
+class TestHistoryScopedIsolation:
+    """Covers the reviewer concern: wurzel calls run() once per upstream file, so a
+    step with multiple dependsOn (or one upstream step sharding its output across
+    files) gets invoked more than once within a single run. Without scoping,
+    prune from one invocation could delete another invocation's just-created
+    documents - reproduced for real against the live API before this fix.
+    """
+
+    def test_list_existing_scoped_to_own_history(self, elevenlabs_env, requests_mock, history_scope):
+        elevenlabs_env.set("NAME_PREFIX", "wurzel/")
+        history_scope("SourceB")
+        step = ElevenLabsKnowledgeBaseStep()
+        requests_mock.get(
+            KB,
+            json=kb_list_payload(
+                ("wurzel/SourceA/shared-name", "doc-a"),
+                ("wurzel/SourceB/shared-name", "doc-b"),
+            ),
+        )
+
+        existing = step._list_existing()
+
+        assert existing == {"wurzel/SourceB/shared-name": "doc-b"}
+        step.finalize()
+
+    def test_prune_does_not_touch_a_different_invocations_document(self, elevenlabs_env, requests_mock, history_scope):
+        elevenlabs_env.set("NAME_PREFIX", "wurzel/")
+        elevenlabs_env.set("PRUNE_STALE", "true")
+
+        # Invocation 1: source A creates its document.
+        history_scope("SourceA")
+        step_a = ElevenLabsKnowledgeBaseStep()
+        doc_a = MarkdownDataContract(md="# A", url="https://example.com/shared-name", keywords="")
+        requests_mock.get(KB, json=kb_list_payload())
+        requests_mock.post(KB_TEXT, json=kb_create_payload("doc-a", "wurzel/SourceA/shared-name"))
+        step_a.run([doc_a])
+        step_a.finalize()
+
+        # Invocation 2: source B, same run, different history/lineage. The listing
+        # reflects source A's document now existing in the workspace.
+        history_scope("SourceB")
+        step_b = ElevenLabsKnowledgeBaseStep()
+        doc_b = MarkdownDataContract(md="# B", url="https://example.com/shared-name", keywords="")
+        requests_mock.get(KB, json=kb_list_payload(("wurzel/SourceA/shared-name", "doc-a")))
+        requests_mock.post(KB_TEXT, json=kb_create_payload("doc-b", "wurzel/SourceB/shared-name"))
+        delete_mock = requests_mock.delete(f"{KB}/doc-a", text="")
+
+        step_b.run([doc_b])
+        step_b.finalize()
+
+        assert not delete_mock.called  # source A's document must survive source B's prune
 
 
 # ── Create / update ────────────────────────────────────────────────────────────

--- a/tests/steps/elevenlabs/step_test.py
+++ b/tests/steps/elevenlabs/step_test.py
@@ -4,6 +4,7 @@
 
 """Unit tests for ElevenLabsKnowledgeBaseStep using requests-mock for HTTP fixtures."""
 
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -346,6 +347,23 @@ class TestListPagination:
         assert get_request.qs.get("types") == ["text"]
         step.finalize()
 
+    def test_parent_folder_id_included_in_list_params(self, elevenlabs_env, sample_doc, requests_mock):
+        """`_create` files new documents under PARENT_FOLDER_ID, so listing must be
+        scoped to the same folder - otherwise every document created there looks
+        "new" again on the next run and gets duplicated instead of updated in
+        place (reproduced against a real KB: https://github.com/telekom/wurzel/pull/247).
+        """
+        elevenlabs_env.set("PARENT_FOLDER_ID", "folder-1")
+        step = ElevenLabsKnowledgeBaseStep()
+        requests_mock.get(KB, json=kb_list_payload())
+        requests_mock.post(KB_TEXT, json=kb_create_payload("doc-1"))
+
+        step.run([sample_doc])
+
+        get_request = next(r for r in requests_mock.request_history if r.method == "GET")
+        assert get_request.qs.get("parent_folder_id") == ["folder-1"]
+        step.finalize()
+
     def test_name_prefix_filters_client_side(self, elevenlabs_env, sample_doc, requests_mock):
         """Out-of-prefix documents must never enter `existing` at all.
 
@@ -579,6 +597,123 @@ class TestPruneStale:
         assert not delete_mock.called
         assert "Skipping prune" in caplog.text
         step.finalize()
+
+
+# ── Re-running against a persistent KB ──────────────────────────────────────────
+
+
+class StatefulFakeKB:
+    """A minimal, stateful in-memory KB backing GET/POST/PATCH/DELETE, so a
+    second `step.run()` call sees documents created by a first one - unlike the
+    other tests here, which only ever mock a single request/response in
+    isolation. Needed to catch bugs that only show up across repeated runs
+    (https://github.com/telekom/wurzel/pull/247#issuecomment-5002614933:
+    documents were never recognized as already existing, so every run just
+    kept creating new copies instead of updating in place).
+    """
+
+    def __init__(self):
+        self.docs: dict[str, dict] = {}
+        self._next_id = 1
+
+    def register(self, requests_mock):
+        requests_mock.get(KB, json=self._list)
+        requests_mock.post(KB_TEXT, json=self._create)
+        requests_mock.patch(re.compile(rf"{re.escape(KB)}/(?!text)([^/?]+)"), json=self._update)
+        requests_mock.delete(re.compile(rf"{re.escape(KB)}/([^/?]+)"), text=self._delete)
+
+    def _list(self, request, context):
+        parent_folder_id = request.qs.get("parent_folder_id", [None])[0]
+        page_size = int(request.qs.get("page_size", ["100"])[0])
+        cursor = request.qs.get("cursor", [None])[0]
+        items = [(doc_id, d) for doc_id, d in self.docs.items() if d["parent_folder_id"] == parent_folder_id]
+        start = int(cursor) if cursor else 0
+        page = items[start : start + page_size]
+        next_start = start + page_size
+        has_more = next_start < len(items)
+        return {
+            "documents": [{"id": doc_id, "name": d["name"], "type": "text"} for doc_id, d in page],
+            "has_more": has_more,
+            "next_cursor": str(next_start) if has_more else None,
+        }
+
+    def _create(self, request, context):
+        doc_id = f"doc-{self._next_id}"
+        self._next_id += 1
+        body = request.json()
+        self.docs[doc_id] = {"name": body["name"], "content": body["text"], "parent_folder_id": body.get("parent_folder_id")}
+        return kb_create_payload(doc_id, body["name"])
+
+    def _update(self, request, context):
+        doc_id = request.path.rsplit("/", 1)[-1]
+        self.docs[doc_id]["content"] = request.json()["content"]
+        return {}
+
+    def _delete(self, request, context):
+        self.docs.pop(request.path.rsplit("/", 1)[-1], None)
+        return ""
+
+
+class TestSecondRun:
+    """Runs the step twice against a StatefulFakeKB - the scenario a Telekom
+    reviewer reported as broken on PR #247: re-running the step (their
+    pipeline's normal, periodic operation) didn't update existing documents in
+    place, it just kept creating new ones, doubling the knowledge base every
+    run. Root cause: `_list_existing` never scoped its GET by PARENT_FOLDER_ID,
+    even though `_create` files new documents under it - so once a document
+    was filed under a folder, every later run's listing failed to see it and
+    treated it as brand new. See `test_parent_folder_id_included_in_list_params`
+    for the direct regression test on that request; these exercise the
+    same fix through two full `run()` calls instead of a single one.
+    """
+
+    def test_second_run_updates_in_place_and_prunes(self, elevenlabs_env, requests_mock):
+        elevenlabs_env.set("NAME_PREFIX", "wurzel/")
+        elevenlabs_env.set("PRUNE_STALE", "true")
+        kb = StatefulFakeKB()
+        kb.register(requests_mock)
+        docs = [MarkdownDataContract(md=f"# Doc {i}", url=f"https://example.com/doc{i}", keywords="") for i in range(3)]
+
+        ElevenLabsKnowledgeBaseStep().run(docs)
+        assert len(kb.docs) == 3
+
+        # Second run, unchanged input: must update in place, not duplicate.
+        ElevenLabsKnowledgeBaseStep().run(docs)
+        assert len(kb.docs) == 3, f"expected update-in-place, got duplicates: {kb.docs}"
+        patch_count = sum(1 for r in requests_mock.request_history if r.method == "PATCH")
+        assert patch_count == 3
+
+        # Third run, one doc removed from the source: must prune it.
+        ElevenLabsKnowledgeBaseStep().run(docs[:2])
+        assert len(kb.docs) == 2, f"expected the removed doc to be pruned, got: {kb.docs}"
+
+    def test_second_run_with_parent_folder_id_does_not_duplicate(self, elevenlabs_env, requests_mock):
+        elevenlabs_env.set("PARENT_FOLDER_ID", "folder-1")
+        kb = StatefulFakeKB()
+        kb.register(requests_mock)
+        docs = [MarkdownDataContract(md=f"# Doc {i}", url=f"https://example.com/doc{i}", keywords="") for i in range(5)]
+
+        ElevenLabsKnowledgeBaseStep().run(docs)
+        assert len(kb.docs) == 5
+
+        ElevenLabsKnowledgeBaseStep().run(docs)
+        assert len(kb.docs) == 5, f"expected update-in-place, got {len(kb.docs)} docs (the reported bug: docs doubled)"
+
+    def test_second_run_at_scale_beyond_one_page(self, elevenlabs_env, requests_mock):
+        """The report showed ~1600 existing documents - comfortably more than one
+        PAGE_SIZE page - so listing must paginate through everything, not just
+        the first page, before deciding what's already there.
+        """
+        elevenlabs_env.set("NAME_PREFIX", "wurzel/")
+        kb = StatefulFakeKB()
+        kb.register(requests_mock)
+        docs = [MarkdownDataContract(md=f"# Doc {i}", url=f"https://example.com/doc{i}", keywords="") for i in range(250)]
+
+        ElevenLabsKnowledgeBaseStep().run(docs)
+        assert len(kb.docs) == 250
+
+        ElevenLabsKnowledgeBaseStep().run(docs)
+        assert len(kb.docs) == 250, f"expected update-in-place across all pages, got {len(kb.docs)} docs"
 
 
 # ── Failure scenarios ──────────────────────────────────────────────────────────

--- a/wurzel/steps/elevenlabs/__init__.py
+++ b/wurzel/steps/elevenlabs/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .settings import ElevenLabsKnowledgeBaseSettings
+from .step import ElevenLabsKnowledgeBaseStep
+
+__all__ = [
+    "ElevenLabsKnowledgeBaseStep",
+    "ElevenLabsKnowledgeBaseSettings",
+]

--- a/wurzel/steps/elevenlabs/settings.py
+++ b/wurzel/steps/elevenlabs/settings.py
@@ -4,6 +4,11 @@
 
 """Settings for the ElevenLabs Knowledge Base connector step."""
 
+# pylint: disable=duplicate-code
+# Each connector step in wurzel/steps/ is an intentionally independent module
+# rather than sharing a base class, so the common TIMEOUT/PUSH_ENABLED field +
+# validator pattern is duplicated by design.
+
 from typing import Self
 
 from pydantic import Field, SecretStr, model_validator

--- a/wurzel/steps/elevenlabs/settings.py
+++ b/wurzel/steps/elevenlabs/settings.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: 2025
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Settings for the ElevenLabs Knowledge Base connector step."""
+
+from typing import Self
+
+from pydantic import Field, SecretStr, model_validator
+
+from wurzel.core.settings import Settings
+
+
+class ElevenLabsKnowledgeBaseSettings(Settings):
+    """Configuration for the ElevenLabs Agents Knowledge Base connector.
+
+    Attributes:
+        API_KEY: API key for authentication (required when PUSH_ENABLED is True).
+        BASE_URL: Base URL for the ElevenLabs API.
+        NAME_PREFIX: Prefix applied to generated document names. Used both to
+            namespace documents created by this pipeline and to scope the
+            list/prune query so unrelated documents in the same workspace are
+            never touched.
+        PARENT_FOLDER_ID: Optional knowledge base folder to file new documents under.
+        TIMEOUT: Request timeout in seconds.
+        PUSH_ENABLED: When False, skip pushing to ElevenLabs and return the input data unchanged.
+        PRUNE_STALE: When True, delete documents present in the knowledge base but
+            absent from the input (so the knowledge base mirrors the input). Requires
+            NAME_PREFIX to be set: the knowledge base is a single flat namespace shared
+            by every integration in the workspace, so without a prefix "absent from the
+            input" would match every other text document in the workspace too.
+        PRUNE_FORCE: When True, prune deletions also remove the document from any
+            agent it is attached to. When False (default) pruning a document still
+            attached to an agent fails and is logged instead of raised.
+        PAGE_SIZE: Number of documents fetched per page when listing existing documents.
+        MAX_RETRIES: Max attempts per HTTP call before giving up.
+        RETRY_BACKOFF: Base delay in seconds for exponential back-off between retries
+            (0 disables sleep): 0.5s, 1s, 2s, ...
+
+    Environment Variables (with ELEVENLABSKNOWLEDGEBASESTEP prefix):
+        ELEVENLABSKNOWLEDGEBASESTEP__API_KEY:          API key for authentication
+        ELEVENLABSKNOWLEDGEBASESTEP__BASE_URL:         ElevenLabs API base URL
+        ELEVENLABSKNOWLEDGEBASESTEP__NAME_PREFIX:      Prefix for generated document names
+        ELEVENLABSKNOWLEDGEBASESTEP__PARENT_FOLDER_ID: Knowledge base folder id for new documents
+        ELEVENLABSKNOWLEDGEBASESTEP__TIMEOUT:          Request timeout in seconds
+        ELEVENLABSKNOWLEDGEBASESTEP__PUSH_ENABLED:     Whether to push documents (default: True)
+        ELEVENLABSKNOWLEDGEBASESTEP__PRUNE_STALE:      Delete documents absent from input (default: False)
+        ELEVENLABSKNOWLEDGEBASESTEP__PRUNE_FORCE:      Force-delete documents attached to agents (default: False)
+        ELEVENLABSKNOWLEDGEBASESTEP__PAGE_SIZE:        Page size when listing existing documents
+        ELEVENLABSKNOWLEDGEBASESTEP__MAX_RETRIES:      Max attempts per HTTP call (default: 3)
+        ELEVENLABSKNOWLEDGEBASESTEP__RETRY_BACKOFF:    Base back-off seconds - 0.5s, 1s, 2s, ... (default: 0.5)
+    """
+
+    API_KEY: SecretStr | None = Field(
+        default=None,
+        description="API key for authentication with ElevenLabs (required when PUSH_ENABLED is True)",
+    )
+    BASE_URL: str = Field(
+        default="https://api.elevenlabs.io",
+        description="Base URL for the ElevenLabs API",
+    )
+    NAME_PREFIX: str = Field(
+        default="",
+        description="Prefix applied to generated document names",
+    )
+    PARENT_FOLDER_ID: str | None = Field(
+        default=None,
+        description="Knowledge base folder id to file new documents under",
+    )
+    TIMEOUT: int = Field(
+        default=120,
+        gt=0,
+        description="Request timeout in seconds",
+    )
+    PUSH_ENABLED: bool = Field(
+        default=True,
+        description="When False, skip pushing to ElevenLabs and return the input data unchanged",
+    )
+    PRUNE_STALE: bool = Field(
+        default=False,
+        description="When True, delete documents in the knowledge base absent from the input",
+    )
+    PRUNE_FORCE: bool = Field(
+        default=False,
+        description="When True, prune deletions also detach the document from any agent using it",
+    )
+    PAGE_SIZE: int = Field(
+        default=100,
+        gt=0,
+        le=100,
+        description="Number of documents fetched per page when listing existing documents",
+    )
+    MAX_RETRIES: int = Field(
+        default=3,
+        gt=0,
+        description="Max attempts per HTTP call before giving up",
+    )
+    RETRY_BACKOFF: float = Field(
+        default=0.5,
+        ge=0,
+        description="Base delay in seconds for exponential back-off between retries (0 disables sleep): 0.5s, 1s, 2s, ...",
+    )
+
+    @model_validator(mode="after")
+    def validate_api_key_when_push_enabled(self) -> Self:
+        """Ensure API_KEY is provided when PUSH_ENABLED is True."""
+        if self.PUSH_ENABLED and self.API_KEY is None:
+            raise ValueError("API_KEY is required when PUSH_ENABLED is True")
+        return self
+
+    @model_validator(mode="after")
+    def validate_name_prefix_when_pruning(self) -> Self:
+        """Require a non-empty NAME_PREFIX whenever PRUNE_STALE is enabled.
+
+        The knowledge base is a single flat namespace shared by every integration
+        in the workspace. Without a prefix, "documents absent from the input" means
+        every other text document in the workspace - PRUNE_STALE would delete
+        content this pipeline never created.
+        """
+        if self.PRUNE_STALE and not self.NAME_PREFIX:
+            raise ValueError("NAME_PREFIX is required when PRUNE_STALE is True")
+        return self

--- a/wurzel/steps/elevenlabs/step.py
+++ b/wurzel/steps/elevenlabs/step.py
@@ -75,8 +75,6 @@ class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, lis
         super().__init__()
         self._session: requests.Session | None = None
         if self.settings.PUSH_ENABLED:
-            if self.settings.API_KEY is None:
-                raise ValueError("API_KEY is required when PUSH_ENABLED is True")
             self._session = requests.Session()
             self._session.headers.update({"xi-api-key": self.settings.API_KEY.get_secret_value()})
 

--- a/wurzel/steps/elevenlabs/step.py
+++ b/wurzel/steps/elevenlabs/step.py
@@ -17,7 +17,7 @@ from urllib.parse import urlparse
 
 import requests
 
-from wurzel.core import TypedStep
+from wurzel.core import TypedStep, step_history
 from wurzel.datacontract import MarkdownDataContract
 from wurzel.exceptions import StepFailed
 
@@ -37,7 +37,15 @@ class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, lis
 
     Document names are derived deterministically from each document's URL (mirroring
     its path), so re-running the step against the same input updates existing
-    documents in place instead of creating duplicates.
+    documents in place instead of creating duplicates. Names are additionally scoped
+    by NAME_PREFIX and a tag derived from ``wurzel.core.step_history`` identifying the
+    current invocation's upstream lineage - stable across successive runs of the same
+    pipeline, but distinct across different upstream sources. This matters because
+    wurzel calls ``run()`` once per upstream file, not once per pipeline run: a step
+    with more than one ``dependsOn``, or a single upstream step that shards its output
+    across files, causes multiple separate invocations within one run, each seeing only
+    its own slice of the data. The history tag ensures each invocation only ever sees
+    and manages its own lineage's documents, never another invocation's.
 
     When PUSH_ENABLED is False the step returns the input data immediately
     without making any API calls.
@@ -46,6 +54,8 @@ class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, lis
     are in the knowledge base but not in the input, so the knowledge base mirrors
     the input. Requires NAME_PREFIX (the knowledge base is a single flat namespace
     shared by every integration in the workspace) and is skipped on any push failure.
+    Scoped by the history tag described above, so pruning one invocation's stale
+    documents never touches a different invocation's documents within the same run.
 
     Environment Variables:
         ELEVENLABSKNOWLEDGEBASESTEP__API_KEY:          API key for authentication (required when PUSH_ENABLED is True)
@@ -133,16 +143,45 @@ class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, lis
                 time.sleep(delay)
         raise RuntimeError("unreachable: retry loop exited without returning or raising")
 
+    def _history_tag(self) -> str:
+        """Scope tag derived from ``step_history``, identifying this invocation's upstream lineage.
+
+        Set by the wurzel Executor (via a ContextVar) right before ``run()`` is called,
+        encoding the chain of upstream steps/files that produced this invocation's
+        input. It is stable across successive runs of the same pipeline (built only
+        from step class names, never a run id or timestamp) but differs across
+        distinct upstream sources - so if this step is fed by more than one source in
+        a single run (multiple ``dependsOn``, or one upstream step sharding its output
+        across files), each invocation gets a different tag. Used by both
+        ``_generate_name`` and ``_list_existing`` so one invocation's create/update/
+        prune decisions never consider a different invocation's documents.
+
+        Falls back to "" (no extra scoping, matching behavior with no history) when
+        unset - e.g. when the step is instantiated directly instead of run through
+        the wurzel Executor.
+        """
+        history = step_history.get()
+        if history is None:
+            return ""
+        tag = "-".join(history.get())
+        return f"{tag}/" if tag else ""
+
     def _list_existing(self) -> dict[str, str]:
         """Return {name: document_id} for existing text documents in our namespace.
 
         Scoped to ``types=text`` (we only ever create text documents) - a plain
-        metadata filter, applied server-side. NAME_PREFIX filtering is done
-        client-side instead of via the API's ``search`` parameter: that is backed
-        by search infrastructure which is not guaranteed to return every matching
-        document (observed in practice missing a document that plainly existed),
-        which would cause us to create a duplicate instead of updating it. Every
-        text document is paginated through and matched by prefix here instead.
+        metadata filter, applied server-side. NAME_PREFIX + history-tag filtering
+        (see ``_history_tag``) is done client-side instead of via the API's
+        ``search`` parameter: that is backed by search infrastructure which is not
+        guaranteed to return every matching document (observed in practice missing
+        a document that plainly existed), which would cause us to create a
+        duplicate instead of updating it. Every text document is paginated through
+        and matched by prefix here instead.
+
+        The history tag additionally scopes this to the current invocation's own
+        upstream lineage, so if this step is invoked more than once within a single
+        run, one invocation's view of "existing" - and therefore its prune
+        decisions - never includes documents belonging to a different invocation.
 
         If two documents share the same name - e.g. a duplicate left over from
         exactly that kind of missed match - the extra copy is deleted so
@@ -154,6 +193,7 @@ class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, lis
         first place - a document on an unfetched page would look "new" and get
         created a second time.
         """
+        scope = f"{self.settings.NAME_PREFIX}{self._history_tag()}"
         existing: dict[str, str] = {}
         cursor: str | None = None
         while True:
@@ -172,7 +212,7 @@ class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, lis
                     # as one of ours, or it could get PATCHed or pruned.
                     continue
                 name = doc["name"]
-                if self.settings.NAME_PREFIX and not name.startswith(self.settings.NAME_PREFIX):
+                if scope and not name.startswith(scope):
                     continue
                 if name in existing:
                     log.warning(f"Duplicate document name {name!r}: keeping {existing[name]}, deleting {doc['id']}")
@@ -191,13 +231,18 @@ class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, lis
         """Mirror the URL path as the document name so the same URL always maps to the same document.
 
         e.g. https://example.com/tmcz/baze/magenta-wi-fi -> tmcz/baze/magenta-wi-fi
+
+        Prefixed with NAME_PREFIX and a history-derived scope tag (see
+        ``_history_tag``), so distinct upstream sources feeding this step within
+        one run never collide in the name-matching namespace used for
+        update-in-place and pruning.
         """
         name = f"document_{idx:04d}"
         if doc.url:
             path = urlparse(doc.url).path.strip("/")
             if path:
                 name = path
-        return f"{self.settings.NAME_PREFIX}{name}" if self.settings.NAME_PREFIX else name
+        return f"{self.settings.NAME_PREFIX}{self._history_tag()}{name}"
 
     def _create(self, name: str, content: str) -> str:
         """POST /knowledge-base/text - create a new text document, returns its id."""
@@ -231,9 +276,11 @@ class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, lis
         """Delete documents that are in the knowledge base but not in the input.
 
         Only ever considers documents returned by ``_list_existing`` - i.e. within
-        our ``types=text`` + NAME_PREFIX namespace - so it never touches documents
-        created outside this step. Best-effort: per-document failures are logged,
-        not raised. Returns the number of documents actually pruned.
+        our ``types=text`` + NAME_PREFIX + history-tag namespace - so it never
+        touches documents created outside this step, nor documents belonging to a
+        different invocation within the same run. Best-effort: per-document
+        failures are logged, not raised. Returns the number of documents actually
+        pruned.
         """
         stale = {name: doc_id for name, doc_id in existing.items() if name not in processed_names}
         if not stale:

--- a/wurzel/steps/elevenlabs/step.py
+++ b/wurzel/steps/elevenlabs/step.py
@@ -75,9 +75,8 @@ class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, lis
         super().__init__()
         self._session: requests.Session | None = None
         if self.settings.PUSH_ENABLED:
-            assert self.settings.API_KEY is not None
             self._session = requests.Session()
-            self._session.headers.update({"xi-api-key": self.settings.API_KEY.get_secret_value()})
+            self._session.headers.update({"xi-api-key": self.settings.API_KEY.get_secret_value()})  # ty: ignore[unresolved-attribute]
 
     def _request(self, method: str, endpoint: str, idempotent: bool = True, **kwargs: Any) -> dict[str, Any]:
         """Make a request to the ElevenLabs API, retrying transient failures.

--- a/wurzel/steps/elevenlabs/step.py
+++ b/wurzel/steps/elevenlabs/step.py
@@ -75,6 +75,7 @@ class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, lis
         super().__init__()
         self._session: requests.Session | None = None
         if self.settings.PUSH_ENABLED:
+            assert self.settings.API_KEY is not None
             self._session = requests.Session()
             self._session.headers.update({"xi-api-key": self.settings.API_KEY.get_secret_value()})
 

--- a/wurzel/steps/elevenlabs/step.py
+++ b/wurzel/steps/elevenlabs/step.py
@@ -260,7 +260,11 @@ class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, lis
 
     def _delete(self, document_id: str) -> None:
         """DELETE /knowledge-base/{id} - remove a document."""
-        self._request("DELETE", f"{KNOWLEDGE_BASE_PATH}/{document_id}", params={"force": self.settings.PRUNE_FORCE})
+        self._request(
+            "DELETE",
+            f"{KNOWLEDGE_BASE_PATH}/{document_id}",
+            params={"force": str(self.settings.PRUNE_FORCE).lower()},
+        )
 
     def _format_error(self, e: requests.exceptions.RequestException) -> str:
         """Format a request exception into a readable error message."""

--- a/wurzel/steps/elevenlabs/step.py
+++ b/wurzel/steps/elevenlabs/step.py
@@ -183,6 +183,11 @@ class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, lis
         run, one invocation's view of "existing" - and therefore its prune
         decisions - never includes documents belonging to a different invocation.
 
+        Also scoped to PARENT_FOLDER_ID when set: ``_create`` files new documents
+        under that folder, so listing must query the same folder or every
+        previously-created document would look "new" on the next run and get
+        duplicated instead of updated in place.
+
         If two documents share the same name - e.g. a duplicate left over from
         exactly that kind of missed match - the extra copy is deleted so
         duplicates self-heal instead of accumulating silently across runs.
@@ -198,6 +203,8 @@ class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, lis
         cursor: str | None = None
         while True:
             params: dict[str, Any] = {"page_size": self.settings.PAGE_SIZE, "types": ["text"]}
+            if self.settings.PARENT_FOLDER_ID:
+                params["parent_folder_id"] = self.settings.PARENT_FOLDER_ID
             if cursor:
                 params["cursor"] = cursor
             try:

--- a/wurzel/steps/elevenlabs/step.py
+++ b/wurzel/steps/elevenlabs/step.py
@@ -1,0 +1,297 @@
+# SPDX-FileCopyrightText: 2025
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""ElevenLabs Knowledge Base connector step for pushing markdown documents."""
+
+import random
+import time
+from logging import getLogger
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+
+from wurzel.core import TypedStep
+from wurzel.datacontract import MarkdownDataContract
+from wurzel.exceptions import StepFailed
+
+from .settings import ElevenLabsKnowledgeBaseSettings
+
+log = getLogger(__name__)
+
+KNOWLEDGE_BASE_PATH = "/v1/convai/knowledge-base"
+
+
+class ElevenLabsKnowledgeBaseStep(TypedStep[ElevenLabsKnowledgeBaseSettings, list[MarkdownDataContract], list[MarkdownDataContract]]):
+    """ElevenLabs Agents Knowledge Base connector step.
+
+    Takes MarkdownDataContract documents and creates or updates a text document
+    per input in the ElevenLabs Knowledge Base, then returns the original input
+    documents unchanged.
+
+    Document names are derived deterministically from each document's URL (mirroring
+    its path), so re-running the step against the same input updates existing
+    documents in place instead of creating duplicates.
+
+    When PUSH_ENABLED is False the step returns the input data immediately
+    without making any API calls.
+
+    Prune (optional, gated by PRUNE_STALE): after processing, delete documents that
+    are in the knowledge base but not in the input, so the knowledge base mirrors
+    the input. Requires NAME_PREFIX (the knowledge base is a single flat namespace
+    shared by every integration in the workspace) and is skipped on any push failure.
+
+    Environment Variables:
+        ELEVENLABSKNOWLEDGEBASESTEP__API_KEY:          API key for authentication (required when PUSH_ENABLED is True)
+        ELEVENLABSKNOWLEDGEBASESTEP__BASE_URL:         ElevenLabs API base URL (default: https://api.elevenlabs.io)
+        ELEVENLABSKNOWLEDGEBASESTEP__NAME_PREFIX:      Prefix for generated document names (default: "", required when PRUNE_STALE is True)
+        ELEVENLABSKNOWLEDGEBASESTEP__PARENT_FOLDER_ID: Knowledge base folder id for new documents
+        ELEVENLABSKNOWLEDGEBASESTEP__TIMEOUT:          Request timeout in seconds (default: 120)
+        ELEVENLABSKNOWLEDGEBASESTEP__PUSH_ENABLED:     Whether to push to ElevenLabs (default: True)
+        ELEVENLABSKNOWLEDGEBASESTEP__PRUNE_STALE:      Delete documents absent from input, mirroring it (default: False)
+        ELEVENLABSKNOWLEDGEBASESTEP__PRUNE_FORCE:      Force-delete documents attached to agents (default: False)
+        ELEVENLABSKNOWLEDGEBASESTEP__PAGE_SIZE:        Page size when listing existing documents (default: 100)
+        ELEVENLABSKNOWLEDGEBASESTEP__MAX_RETRIES:      Max attempts per HTTP call (default: 3)
+        ELEVENLABSKNOWLEDGEBASESTEP__RETRY_BACKOFF:    Base back-off seconds - 0.5s, 1s, 2s, ... (default: 0.5)
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._session: requests.Session | None = None
+        if self.settings.PUSH_ENABLED:
+            if self.settings.API_KEY is None:
+                raise ValueError("API_KEY is required when PUSH_ENABLED is True")
+            self._session = requests.Session()
+            self._session.headers.update({"xi-api-key": self.settings.API_KEY.get_secret_value()})
+
+    def _request(self, method: str, endpoint: str, idempotent: bool = True, **kwargs: Any) -> dict[str, Any]:
+        """Make a request to the ElevenLabs API, retrying transient failures.
+
+        Some endpoints (e.g. DELETE) return an empty body rather than JSON;
+        treat that as an empty result instead of failing to parse it.
+        """
+
+        def _do_request() -> dict[str, Any]:
+            if self._session is None:
+                raise StepFailed("ElevenLabs session is not initialized")
+            response = self._session.request(
+                method,
+                f"{self.settings.BASE_URL}{endpoint}",
+                timeout=self.settings.TIMEOUT,
+                **kwargs,
+            )
+            response.raise_for_status()
+            if not response.content:
+                return {}
+            return response.json()
+
+        return self._with_retry(_do_request, idempotent=idempotent)
+
+    @staticmethod
+    def _should_retry(exc: requests.exceptions.RequestException, idempotent: bool) -> bool:
+        """Whether ``exc`` is a transient error worth retrying.
+
+        - Read timeout: the server may already have processed the request, so only
+          retry idempotent calls - re-sending a create would duplicate the document.
+        - Connect timeout / connection error: the request never reached the server,
+          so it is always safe to retry.
+        - HTTP 429 / 5xx: transient server-side, safe to retry.
+        - Other 4xx: permanent client error, never retry.
+        """
+        if isinstance(exc, requests.exceptions.ReadTimeout):
+            return idempotent
+        if isinstance(exc, requests.exceptions.ConnectTimeout | requests.exceptions.ConnectionError):
+            return True
+        if isinstance(exc, requests.exceptions.Timeout):
+            return idempotent
+        if isinstance(exc, requests.exceptions.HTTPError) and exc.response is not None:
+            return exc.response.status_code == 429 or exc.response.status_code >= 500
+        return False
+
+    def _with_retry(self, fn: Any, *, idempotent: bool) -> Any:
+        """Call fn() with full-jitter exponential back-off retry.
+
+        Only transient request errors are retried (see ``_should_retry``); permanent
+        errors propagate immediately. ``idempotent=False`` is used for calls that
+        must not be re-sent after a read timeout (e.g. document creation).
+        """
+        for attempt in range(self.settings.MAX_RETRIES):
+            try:
+                return fn()
+            except requests.exceptions.RequestException as exc:
+                is_last = attempt == self.settings.MAX_RETRIES - 1
+                if is_last or not self._should_retry(exc, idempotent):
+                    raise
+                delay = random.uniform(0, self.settings.RETRY_BACKOFF * (2**attempt))
+                log.warning(f"Attempt {attempt + 1}/{self.settings.MAX_RETRIES} failed: {exc}; retrying in {delay:.2f}s")
+                time.sleep(delay)
+        raise RuntimeError("unreachable: retry loop exited without returning or raising")
+
+    def _list_existing(self) -> dict[str, str]:
+        """Return {name: document_id} for existing text documents in our namespace.
+
+        Scoped to ``types=text`` (we only ever create text documents) - a plain
+        metadata filter, applied server-side. NAME_PREFIX filtering is done
+        client-side instead of via the API's ``search`` parameter: that is backed
+        by search infrastructure which is not guaranteed to return every matching
+        document (observed in practice missing a document that plainly existed),
+        which would cause us to create a duplicate instead of updating it. Every
+        text document is paginated through and matched by prefix here instead.
+
+        If two documents share the same name - e.g. a duplicate left over from
+        exactly that kind of missed match - the extra copy is deleted so
+        duplicates self-heal instead of accumulating silently across runs.
+
+        Raises StepFailed (rather than falling back to an empty/partial result)
+        if the listing can't be completed even after retries: proceeding with an
+        incomplete view of what already exists is what causes duplicates in the
+        first place - a document on an unfetched page would look "new" and get
+        created a second time.
+        """
+        existing: dict[str, str] = {}
+        cursor: str | None = None
+        while True:
+            params: dict[str, Any] = {"page_size": self.settings.PAGE_SIZE, "types": ["text"]}
+            if cursor:
+                params["cursor"] = cursor
+            try:
+                result = self._request("GET", KNOWLEDGE_BASE_PATH, params=params)
+            except requests.exceptions.RequestException as e:
+                raise StepFailed(f"Could not list existing knowledge base documents: {self._format_error(e)}") from e
+            for doc in result.get("documents", []):
+                if doc.get("type") != "text":
+                    # Defensive: don't trust the server-side `types=text` filter alone
+                    # (`type` is the discriminator between text/url/file/folder
+                    # documents) - a leaked non-text document must never be treated
+                    # as one of ours, or it could get PATCHed or pruned.
+                    continue
+                name = doc["name"]
+                if self.settings.NAME_PREFIX and not name.startswith(self.settings.NAME_PREFIX):
+                    continue
+                if name in existing:
+                    log.warning(f"Duplicate document name {name!r}: keeping {existing[name]}, deleting {doc['id']}")
+                    try:
+                        self._delete(doc["id"])
+                    except requests.exceptions.RequestException as e:
+                        log.warning(f"Failed to delete duplicate {doc['id']} for {name!r}: {self._format_error(e)}")
+                    continue
+                existing[name] = doc["id"]
+            cursor = result.get("next_cursor")
+            if not result.get("has_more") or not cursor:
+                break
+        return existing
+
+    def _generate_name(self, doc: MarkdownDataContract, idx: int) -> str:
+        """Mirror the URL path as the document name so the same URL always maps to the same document.
+
+        e.g. https://example.com/tmcz/baze/magenta-wi-fi -> tmcz/baze/magenta-wi-fi
+        """
+        name = f"document_{idx:04d}"
+        if doc.url:
+            path = urlparse(doc.url).path.strip("/")
+            if path:
+                name = path
+        return f"{self.settings.NAME_PREFIX}{name}" if self.settings.NAME_PREFIX else name
+
+    def _create(self, name: str, content: str) -> str:
+        """POST /knowledge-base/text - create a new text document, returns its id."""
+        payload: dict[str, Any] = {"text": content, "name": name}
+        if self.settings.PARENT_FOLDER_ID:
+            payload["parent_folder_id"] = self.settings.PARENT_FOLDER_ID
+        # Not retried on a read timeout: the server may already have created it,
+        # and re-sending would create a duplicate.
+        result = self._request("POST", f"{KNOWLEDGE_BASE_PATH}/text", idempotent=False, json=payload)
+        return result["id"]
+
+    def _update(self, document_id: str, content: str) -> None:
+        """PATCH /knowledge-base/{id} - overwrite the content of an existing text document."""
+        self._request("PATCH", f"{KNOWLEDGE_BASE_PATH}/{document_id}", json={"content": content})
+
+    def _delete(self, document_id: str) -> None:
+        """DELETE /knowledge-base/{id} - remove a document."""
+        self._request("DELETE", f"{KNOWLEDGE_BASE_PATH}/{document_id}", params={"force": self.settings.PRUNE_FORCE})
+
+    def _format_error(self, e: requests.exceptions.RequestException) -> str:
+        """Format a request exception into a readable error message."""
+        if hasattr(e, "response") and e.response is not None:
+            try:
+                detail = e.response.json().get("detail", str(e))
+                return f"{e.response.status_code}: {detail}"
+            except (ValueError, KeyError):
+                return f"{e.response.status_code}: {e.response.text or str(e)}"
+        return str(e)
+
+    def _prune_stale(self, existing: dict[str, str], processed_names: set[str]) -> int:
+        """Delete documents that are in the knowledge base but not in the input.
+
+        Only ever considers documents returned by ``_list_existing`` - i.e. within
+        our ``types=text`` + NAME_PREFIX namespace - so it never touches documents
+        created outside this step. Best-effort: per-document failures are logged,
+        not raised. Returns the number of documents actually pruned.
+        """
+        stale = {name: doc_id for name, doc_id in existing.items() if name not in processed_names}
+        if not stale:
+            return 0
+        log.info(f"Pruning {len(stale)} stale document(s) not in input: {sorted(stale)[:10]}{' ...' if len(stale) > 10 else ''}")
+        pruned = 0
+        for name, doc_id in stale.items():
+            try:
+                self._delete(doc_id)
+                pruned += 1
+            except requests.exceptions.RequestException as e:
+                log.warning(f"Failed to prune {name}: {self._format_error(e)}")
+        return pruned
+
+    def run(self, inpt: list[MarkdownDataContract]) -> list[MarkdownDataContract]:
+        """Push markdown documents to the ElevenLabs Knowledge Base and return them unchanged."""
+        if not self.settings.PUSH_ENABLED:
+            log.info("Push disabled, returning input data without pushing to ElevenLabs")
+            return inpt
+
+        if not inpt:
+            log.warning("No documents to process")
+            return inpt
+
+        existing = self._list_existing()
+        log.info(f"Processing {len(inpt)} documents for ElevenLabs Knowledge Base")
+
+        success_count = 0
+        failed_count = 0
+        processed_names: set[str] = set()
+
+        for idx, doc in enumerate(inpt):
+            name = self._generate_name(doc, idx)
+            processed_names.add(name)
+            try:
+                existing_id = existing.get(name)
+                if existing_id:
+                    self._update(existing_id, doc.md)
+                    log.info(f"Updated: {name}")
+                else:
+                    existing[name] = self._create(name, doc.md)
+                    log.info(f"Created: {name}")
+                success_count += 1
+            except requests.exceptions.RequestException as e:
+                log.error(f"Failed to push {name}: {self._format_error(e)}")
+                failed_count += 1
+
+        pruned = 0
+        if self.settings.PRUNE_STALE:
+            if failed_count > 0:
+                log.warning(f"Skipping prune: {failed_count} document(s) failed to push this run")
+            else:
+                pruned = self._prune_stale(existing, processed_names)
+
+        log.info(f"Completed: {success_count} succeeded, {failed_count} failed, {pruned} pruned")
+
+        if failed_count > 0 and success_count == 0:
+            raise StepFailed(f"All {failed_count} documents failed to push to ElevenLabs")
+
+        return inpt
+
+    def finalize(self) -> None:
+        """Cleanup after step execution."""
+        if self._session is not None:
+            self._session.close()
+        super().finalize()

--- a/wurzel/steps/elevenlabs/step.py
+++ b/wurzel/steps/elevenlabs/step.py
@@ -4,6 +4,11 @@
 
 """ElevenLabs Knowledge Base connector step for pushing markdown documents."""
 
+# pylint: disable=duplicate-code
+# Each connector step in wurzel/steps/ is an intentionally independent module
+# rather than sharing a base class, so the retry/back-off logic, error
+# formatting, and session-init pattern are duplicated by design.
+
 import random
 import time
 from logging import getLogger


### PR DESCRIPTION
## Description
<!--Please include a summary of the changes and the related issue. Please also include relevant motivation and context.-->
Introduces ElevenLabsKnowledgeBaseStep, a connector that syncs MarkdownDataContract documents into ElevenLabs' Conversational AI Knowledge Base.

For each input document, it either creates a new text document (POST /v1/convai/knowledge-base/text) or updates an existing one in place (PATCH /v1/convai/knowledge-base/{id}), matching is done by a name derived from the document's URL, so running the pipeline again edits the same documents rather than piling up duplicates. With PRUNE_STALE enabled, it can also remove documents that used to be in the input but no longer are, keeping the knowledge base in sync with the pipeline's output. The input list is returned unchanged so the step can chain with others downstream.

Settings (ELEVENLABSKNOWLEDGEBASESTEP__ prefix):
- API_KEY — required, auth for the ElevenLabs API
- BASE_URL — defaults to https://api.elevenlabs.io
- NAME_PREFIX — namespaces generated document names; must be set if PRUNE_STALE is on
- PARENT_FOLDER_ID — optional KB folder for newly created documents
- PRUNE_STALE — off by default; deletes documents no longer in the input
- TIMEOUT — per-request timeout, default 120s

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run the linter and ensured the code is formatted correctly
- [ ] I have updated the documentation accordingly


<!--
Thank you for your contribution! Your efforts help improve the project and are greatly appreciated.-->
