### PR TITLE
fix: construct Argo VolumeMount via model_validate for ty compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "lxml>=5.2,<6.1",
     "pyyaml>=6.0.2",
     "pip<26",
+    "typer>=0.12,<1",
 ]
 
 [project.optional-dependencies]

--- a/wurzel/executors/backend/backend_argo.py
+++ b/wurzel/executors/backend/backend_argo.py
@@ -296,10 +296,12 @@ class ArgoBackend(Backend, backend_name="argo"):
             for mapping in secret_mount.mappings:
                 mount_path = secret_mount.destination / mapping.value
                 mounts.append(
-                    VolumeMount(
-                        name=volume_name,
-                        mount_path=mount_path.as_posix(),
-                        sub_path=mapping.key,
+                    VolumeMount.model_validate(
+                        {
+                            "name": volume_name,
+                            "mountPath": mount_path.as_posix(),
+                            "subPath": mapping.key,
+                        }
                     )
                 )
 
@@ -327,10 +329,12 @@ class ArgoBackend(Backend, backend_name="argo"):
                     )
                 )
             mounts.append(
-                VolumeMount(
-                    name=volume_name,
-                    mount_path=tokenizer_cache.mountPath,
-                    read_only=tokenizer_cache.readOnly,
+                VolumeMount.model_validate(
+                    {
+                        "name": volume_name,
+                        "mountPath": tokenizer_cache.mountPath,
+                        "readOnly": tokenizer_cache.readOnly,
+                    }
                 )
             )
 


### PR DESCRIPTION
## Summary

Fixes the `ty` type-checker failure in CI on the Argo backend:

```
error[missing-argument]: No argument provided for required parameter `mountPath`
  --> wurzel/executors/backend/backend_argo.py
```

Newer `ty` versions infer pydantic constructors by field **alias** (`mountPath`), while older versions use the field name (`mount_path`). The two `VolumeMount(...)` calls used field names, which the CI `ty` version rejected. Since the alias vs. field-name convention differs across `ty` versions, both constructions now use `VolumeMount.model_validate({...})` with alias keys, which sidesteps keyword-parameter inference entirely and works at runtime and across `ty` versions.

## Testing
- `ty check wurzel` passes
- `pytest tests/backend/test_backend_argo.py` — 140 passed