### PR TITLE
fix: satisfy ty type checker in typed_step on Linux/3.11

### DIFF
--- a/wurzel/core/typed_step.py
+++ b/wurzel/core/typed_step.py
@@ -8,6 +8,7 @@ from logging import getLogger
 from pathlib import Path
 from types import NoneType
 from typing import (
+    Any,
     Generic,
     Self,
     TypeAlias,
@@ -130,7 +131,7 @@ class TypedStep(Step, Generic[SETTS, INCONTRACT, OUTCONTRACT]):
                 list_or_type = NoneType
             return containers, cast(type, list_or_type)  # list_or_type is now a type.
         if origin_t in cls._supported_containers:
-            containers.insert(0, origin_t)
+            containers.insert(0, cast(type[Iterable], origin_t))
         else:
             raise StaticTypeError(f"{origin_t} is not a supported container")
         if len(get_args(list_or_type)) == 1:
@@ -194,10 +195,10 @@ class TypedStep(Step, Generic[SETTS, INCONTRACT, OUTCONTRACT]):
             # construct type using only list instead of List
             return_annotation = run_retur_orig
             for container in run_retur_cons or []:
-                return_annotation = container[return_annotation]
+                return_annotation = cast(Any, container)[return_annotation]
             input_annotation = run_input_orig
             for container in run_input_cons or []:
-                input_annotation = container[input_annotation]
+                input_annotation = cast(Any, container)[input_annotation]
             # Check if inputs was in list
             if input_annotation != expected_run_input:
                 raise StaticTypeError(


### PR DESCRIPTION
## Problem

The Lint CI job fails on `main` (run [29584967420](https://github.com/telekom/wurzel/actions/runs/29584967420/job/87899576945)). The `ty` type-checker hook reports 5 diagnostics in `wurzel/core/typed_step.py`:

```
error[invalid-argument-type]: Argument to bound method `list.insert` is incorrect
  --> wurzel/core/typed_step.py:133   Expected `type[Iterable[Unknown]]`, found `type`
error[not-subscriptable]: Cannot subscript object of type `type[Iterable[Unknown]]`
  --> wurzel/core/typed_step.py:197
  --> wurzel/core/typed_step.py:200
```

These only surface in CI (Linux + Python 3.11), not on macOS/3.12, because `ty` resolves the container generics differently across environments.

## Fix

Add explicit `cast`s in `_unpack_list_containers` / `_static_type_check_run` so container unpacking is type-sound on any platform. These are runtime no-ops.

## Verification

- `make lint` (incl. `ty`) passes locally
- `typed_step` tests pass