### PR TITLE
feat: async step execution + initial httpx migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ dependencies = [
 
 [project.optional-dependencies]
 qdrant = [
-    "qdrant-client==1.15.1"
+    "qdrant-client==1.15.1",
+    "httpx>=0.27,<1",
 ]
 docling = [
     "docling==2.30.0"
@@ -117,6 +118,7 @@ test = [
     "pytest-xdist==3.*",
     "pytest-mock==3.*",
     "requests-mock==1.*",
+    "httpx>=0.27,<1",
     "moto[s3]>=5.0",
     #"milvus-lite==2.*", # used for miluvs mock no support for windows https://github.com/milvus-io/milvus-lite/issues/176
 ]

--- a/tests/core/run_test.py
+++ b/tests/core/run_test.py
@@ -26,6 +26,15 @@ def test_run_ok(tmp_path):
     BaseStepExecutor().execute_step(MyStep, (A(i=9),), tmp_path / "out.json")
 
 
+def test_run_ok_async(tmp_path):
+    class MyAsyncStep(TypedStep[NoSettings, A, A]):
+        async def run(self, inpt: A) -> A:
+            return A(i=inpt.i + 1)
+
+    result = BaseStepExecutor().execute_step(MyAsyncStep, (A(i=9),), tmp_path / "out.json")
+    assert result[0][0] == A(i=10)
+
+
 @pytest.mark.parametrize(
     "return_value",
     [

--- a/tests/executors/middleware_test.py
+++ b/tests/executors/middleware_test.py
@@ -23,6 +23,13 @@ class DummyStep(TypedStep[None, None, MarkdownDataContract]):
         return MarkdownDataContract(md="test", keywords="test", url="test")
 
 
+class AsyncDummyStep(TypedStep[None, None, MarkdownDataContract]):
+    """Async dummy step for testing middleware compatibility."""
+
+    async def run(self, inpt: None) -> MarkdownDataContract:
+        return MarkdownDataContract(md="test-async", keywords="test", url="test")
+
+
 class TrackerMiddleware(BaseMiddleware):
     """Middleware that tracks execution for testing."""
 
@@ -69,6 +76,19 @@ def test_middleware_chain_single(tmp_path: Path):
         assert tracker.calls[1] == ("after", "DummyStep")
 
     assert tracker.exited
+
+
+def test_middleware_chain_single_with_async_step(tmp_path: Path):
+    """Test executor with middleware and async step implementation."""
+    tracker = TrackerMiddleware()
+
+    with BaseStepExecutor(middlewares=[tracker], load_middlewares_from_env=False) as exc:
+        result = exc(AsyncDummyStep, None, tmp_path)
+        assert result
+        assert result[0][0].md == "test-async"
+        assert len(tracker.calls) == 2
+        assert tracker.calls[0] == ("before", "AsyncDummyStep")
+        assert tracker.calls[1] == ("after", "AsyncDummyStep")
 
 
 def test_middleware_chain_multiple(tmp_path: Path):

--- a/tests/steps/decagon/e2e_test.py
+++ b/tests/steps/decagon/e2e_test.py
@@ -6,8 +6,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
-import requests
 
 from wurzel.datacontract import MarkdownDataContract
 from wurzel.exceptions import StepFailed
@@ -37,7 +37,7 @@ def sample_doc():
 @pytest.fixture
 def mock_session(decagon_env):
     """Create a step with mocked session."""
-    with patch("wurzel.steps.decagon.step.requests.Session") as mock_session_cls:
+    with patch("wurzel.steps.decagon.step.httpx.Client") as mock_session_cls:
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
         step = DecagonKnowledgeBaseStep()
@@ -50,7 +50,7 @@ class TestDecagonKnowledgeBaseStepInit:
 
     def test_init_sets_headers(self, decagon_env):
         """Test that init sets proper authorization headers."""
-        with patch("wurzel.steps.decagon.step.requests.Session") as mock_session_cls:
+        with patch("wurzel.steps.decagon.step.httpx.Client") as mock_session_cls:
             mock_session = MagicMock()
             mock_session_cls.return_value = mock_session
             step = DecagonKnowledgeBaseStep()
@@ -64,7 +64,7 @@ class TestDecagonKnowledgeBaseStepInit:
     def test_init_skips_session_when_push_disabled(self, env):
         """Test that no session is created when PUSH_ENABLED is False."""
         env.set("PUSH_ENABLED", "false")
-        with patch("wurzel.steps.decagon.step.requests.Session") as mock_session_cls:
+        with patch("wurzel.steps.decagon.step.httpx.Client") as mock_session_cls:
             step = DecagonKnowledgeBaseStep()
             mock_session_cls.assert_not_called()
             step.finalize()
@@ -126,7 +126,7 @@ class TestSuccessfulProcessing:
     def test_push_disabled_returns_input_without_api_calls(self, env, sample_doc):
         """Test that PUSH_ENABLED=False returns input without any API calls."""
         env.set("PUSH_ENABLED", "false")
-        with patch("wurzel.steps.decagon.step.requests.Session") as mock_session_cls:
+        with patch("wurzel.steps.decagon.step.httpx.Client") as mock_session_cls:
             step = DecagonKnowledgeBaseStep()
             result = step.run([sample_doc])
 
@@ -142,7 +142,7 @@ class TestChunkingFailure:
         """Test that chunking failure raises StepFailed when all fail."""
         step, mock_sess = mock_session
 
-        mock_sess.post.side_effect = requests.exceptions.ConnectionError("Connection failed")
+        mock_sess.post.side_effect = httpx.RequestError("Connection failed")
 
         with pytest.raises(StepFailed, match="All 1 chunks failed"):
             step.run([sample_doc])
@@ -168,7 +168,7 @@ class TestChunkingFailure:
         mock_sess.post.side_effect = [
             chunk_response,
             article_response,
-            requests.exceptions.ConnectionError("Failed"),
+            httpx.RequestError("Failed"),
         ]
 
         result = step.run(docs)
@@ -189,8 +189,11 @@ class TestArticleCreationFailure:
         error_response = MagicMock()
         error_response.status_code = 500
         error_response.json.return_value = {"detail": "Server error"}
-        exc = requests.exceptions.HTTPError()
-        exc.response = error_response
+        exc = httpx.HTTPStatusError(
+            "Server error",
+            request=httpx.Request("POST", "https://api.test.decagon.ai/article/new"),
+            response=error_response,
+        )
 
         mock_sess.post.side_effect = [chunk_response, exc]
 
@@ -205,7 +208,7 @@ class TestArticleCreationFailure:
         chunk_response.json.return_value = {"chunks": ["chunk1", "chunk2"]}
         chunk_response.raise_for_status = MagicMock()
 
-        exc = requests.exceptions.ConnectionError("Failed")
+        exc = httpx.RequestError("Failed")
 
         mock_sess.post.side_effect = [chunk_response, exc, exc]
 
@@ -224,7 +227,7 @@ class TestArticleCreationFailure:
         success_response.json.return_value = {"article_id": 789}
         success_response.raise_for_status = MagicMock()
 
-        exc = requests.exceptions.ConnectionError("Failed")
+        exc = httpx.RequestError("Failed")
 
         mock_sess.post.side_effect = [chunk_response, success_response, exc]
 
@@ -308,8 +311,11 @@ class TestFormatError:
         response.status_code = 400
         response.json.return_value = {"detail": "Bad request"}
 
-        exc = requests.exceptions.HTTPError()
-        exc.response = response
+        exc = httpx.HTTPStatusError(
+            "Bad request",
+            request=httpx.Request("POST", "https://api.test.decagon.ai/article/new"),
+            response=response,
+        )
 
         assert step._format_error(exc) == "400: Bad request"
 
@@ -322,8 +328,11 @@ class TestFormatError:
         response.json.side_effect = ValueError("Not JSON")
         response.text = "Internal Server Error"
 
-        exc = requests.exceptions.HTTPError()
-        exc.response = response
+        exc = httpx.HTTPStatusError(
+            "Internal Server Error",
+            request=httpx.Request("POST", "https://api.test.decagon.ai/article/new"),
+            response=response,
+        )
 
         assert step._format_error(exc) == "500: Internal Server Error"
 
@@ -331,7 +340,7 @@ class TestFormatError:
         """Test error formatting when no response attached."""
         step, _ = mock_session
 
-        exc = requests.exceptions.ConnectionError("Connection refused")
+        exc = httpx.RequestError("Connection refused")
 
         assert step._format_error(exc) == "Connection refused"
 
@@ -344,8 +353,11 @@ class TestFormatError:
         response.json.side_effect = ValueError()
         response.text = ""
 
-        exc = requests.exceptions.HTTPError("Service Unavailable")
-        exc.response = response
+        exc = httpx.HTTPStatusError(
+            "Service Unavailable",
+            request=httpx.Request("POST", "https://api.test.decagon.ai/article/new"),
+            response=response,
+        )
 
         result = step._format_error(exc)
         assert "503" in result
@@ -356,7 +368,7 @@ class TestFinalize:
 
     def test_finalize_closes_session(self, decagon_env):
         """Test that finalize closes the session."""
-        with patch("wurzel.steps.decagon.step.requests.Session") as mock_session_cls:
+        with patch("wurzel.steps.decagon.step.httpx.Client") as mock_session_cls:
             mock_session = MagicMock()
             mock_session_cls.return_value = mock_session
 
@@ -368,7 +380,7 @@ class TestFinalize:
     def test_finalize_no_session_when_push_disabled(self, env):
         """Test that finalize is safe when no session was created."""
         env.set("PUSH_ENABLED", "false")
-        with patch("wurzel.steps.decagon.step.requests.Session") as mock_session_cls:
+        with patch("wurzel.steps.decagon.step.httpx.Client") as mock_session_cls:
             step = DecagonKnowledgeBaseStep()
             step.finalize()  # should not raise
             mock_session_cls.assert_not_called()

--- a/tests/steps/qdrant/retirement_test.py
+++ b/tests/steps/qdrant/retirement_test.py
@@ -247,7 +247,7 @@ def test_get_telemetry_success(env, dummy_collection):
 
     with patch("wurzel.steps.qdrant.step.QdrantClient") as mock_client:
         mock_client.return_value = client
-        with patch("wurzel.steps.qdrant.retirement.requests.get", return_value=mock_response) as mock_get:
+        with patch("wurzel.steps.qdrant.retirement.httpx.get", return_value=mock_response) as mock_get:
             step = QdrantConnectorStep()
             retirer = CollectionRetirer(step.client, step.settings)
             result = retirer._get_telemetry(details_level=3)
@@ -338,7 +338,7 @@ def test_get_telemetry_unexpected_response(env, dummy_collection, response_body,
 
     with patch("wurzel.steps.qdrant.step.QdrantClient") as mock_client:
         mock_client.return_value = client
-        with patch("wurzel.steps.qdrant.retirement.requests.get", return_value=mock_response):
+        with patch("wurzel.steps.qdrant.retirement.httpx.get", return_value=mock_response):
             step = QdrantConnectorStep()
             retirer = CollectionRetirer(step.client, step.settings)
             if expected_exception is not None:

--- a/wurzel/executors/base_executor.py
+++ b/wurzel/executors/base_executor.py
@@ -4,6 +4,8 @@
 
 """Base Executor."""
 
+import asyncio
+import inspect
 import json
 import os
 import time
@@ -336,7 +338,11 @@ class BaseStepExecutor:
                 token = step_history.set(history)
                 ctx.run(step_history.set, history)
                 try:
-                    res = ctx.run(run, inpt)
+                    run_result = ctx.run(run, inpt)
+                    if inspect.isawaitable(run_result):
+                        res = self._run_awaitable(run_result)
+                    else:
+                        res = run_result
                 finally:
                     step_history.reset(token)
                 run_time = time.time() - run_start
@@ -372,6 +378,15 @@ class BaseStepExecutor:
             step.finalize()
         except ValidationError as err:
             raise ContractFailedException(f"{inputs} does not conform the data contract of {step.input_model_class.__name__}") from err
+
+    @staticmethod
+    def _run_awaitable(awaitable: Any) -> Any:
+        """Run a coroutine/awaitable and return its result.
+
+        This keeps execute_step synchronous while supporting async step.run
+        implementations transparently.
+        """
+        return asyncio.run(awaitable)
 
     def execute_step(
         self,

--- a/wurzel/steps/decagon/step.py
+++ b/wurzel/steps/decagon/step.py
@@ -7,7 +7,7 @@
 from logging import getLogger
 from typing import Any
 
-import requests
+import httpx
 
 from wurzel.core import TypedStep
 from wurzel.datacontract import MarkdownDataContract
@@ -38,11 +38,11 @@ class DecagonKnowledgeBaseStep(TypedStep[DecagonSettings, list[MarkdownDataContr
 
     def __init__(self) -> None:
         super().__init__()
-        self._session: requests.Session | None = None
+        self._session: httpx.Client | None = None
         if self.settings.PUSH_ENABLED:
             if self.settings.API_KEY is None:
                 raise ValueError("API_KEY is required when PUSH_ENABLED is True")
-            self._session = requests.Session()
+            self._session = httpx.Client()
             self._session.headers.update(
                 {
                     "Content-Type": "application/json",
@@ -107,14 +107,15 @@ class DecagonKnowledgeBaseStep(TypedStep[DecagonSettings, list[MarkdownDataContr
 
         return doc.md.split("\n")[0].strip()[:100] or "Untitled"
 
-    def _format_error(self, e: requests.exceptions.RequestException) -> str:
+    def _format_error(self, e: httpx.HTTPError) -> str:
         """Format a request exception into a readable error message."""
-        if hasattr(e, "response") and e.response is not None:
+        response = getattr(e, "response", None)
+        if response is not None:
             try:
-                detail = e.response.json().get("detail", str(e))
-                return f"{e.response.status_code}: {detail}"
+                detail = response.json().get("detail", str(e))
+                return f"{response.status_code}: {detail}"
             except (ValueError, KeyError):
-                return f"{e.response.status_code}: {e.response.text or str(e)}"
+                return f"{response.status_code}: {response.text or str(e)}"
         return str(e)
 
     def run(self, inpt: list[MarkdownDataContract]) -> list[MarkdownDataContract]:
@@ -134,7 +135,7 @@ class DecagonKnowledgeBaseStep(TypedStep[DecagonSettings, list[MarkdownDataContr
         for doc in inpt:
             try:
                 chunks = self._chunk_content(doc.md, self._extract_title(doc))
-            except requests.exceptions.RequestException as e:
+            except httpx.HTTPError as e:
                 log.error(f"Failed to chunk {doc.url}: {self._format_error(e)}")
                 failed_count += 1
                 continue
@@ -143,7 +144,7 @@ class DecagonKnowledgeBaseStep(TypedStep[DecagonSettings, list[MarkdownDataContr
                 try:
                     self._create_article(chunk, doc, idx, len(chunks))
                     success_count += 1
-                except requests.exceptions.RequestException as e:
+                except httpx.HTTPError as e:
                     log.error(f"Failed to create article for {doc.url} chunk {idx + 1}/{len(chunks)}: {self._format_error(e)}")
                     failed_count += 1
 

--- a/wurzel/steps/qdrant/retirement.py
+++ b/wurzel/steps/qdrant/retirement.py
@@ -7,7 +7,7 @@
 from datetime import UTC, datetime, timedelta
 from logging import getLogger
 
-import requests
+import httpx
 from qdrant_client import QdrantClient
 
 from .settings import QdrantSettings
@@ -69,11 +69,11 @@ class CollectionRetirer:
         url = f"{self._settings.URI}/telemetry?details_level={details_level}"
         headers = {"api-key": self._settings.APIKEY.get_secret_value()}
         try:
-            response = requests.get(url, headers=headers, timeout=self._settings.REQUEST_TIMEOUT)
+            response = httpx.get(url, headers=headers, timeout=self._settings.REQUEST_TIMEOUT)
             response.raise_for_status()
             parsed = TelemetryResponse.model_validate(response.json())
             return parsed.result.collections.collections or []
-        except requests.RequestException as e:
+        except httpx.HTTPError as e:
             raise RuntimeError(f"Failed to fetch telemetry from Qdrant: {e}") from e
 
     def _retire_or_log(self, collection_name: str) -> None:


### PR DESCRIPTION
## Summary
- add transparent async support in executor for async step `run` while keeping sync executor API
- add regression tests for async step execution and middleware wrapping
- migrate initial HTTP usage from `requests` to `httpx` in:
  - qdrant retirement telemetry
  - decagon connector
- update related tests to new httpx mocks/exceptions

## Validation
- `pytest tests/core/run_test.py tests/executors/middleware_test.py tests/steps/qdrant/retirement_test.py tests/steps/decagon/e2e_test.py -q`
- `make lint`

## Notes
- this is wave 1 of the planned requests -> httpx migration
- no breaking change to existing synchronous step execution
