### PR TITLE
feat: add ephemeral storage requests and limits to Argo backend

### DIFF
--- a/docs/backends/argoworkflows.md
+++ b/docs/backends/argoworkflows.md
@@ -301,6 +301,8 @@ argo list --label workflows.argoproj.io/cron-workflow=my-scheduled-pipeline
 | `cpu_limit` | string/null | `null` | Optional CPU limit |
 | `memory_request` | string | `128Mi` | Memory request |
 | `memory_limit` | string | `512Mi` | Memory limit |
+| `ephemeral_request` | string/null | `null` | Ephemeral storage request |
+| `ephemeral_limit` | string/null | `null` | Ephemeral storage limit |
 
 #### Tokenizer Cache Options
 

--- a/tests/backend/test_backend_argo.py
+++ b/tests/backend/test_backend_argo.py
@@ -149,6 +149,8 @@ class TestResourcesConfig:
         assert config.cpu_limit is None
         assert config.memory_request == "128Mi"
         assert config.memory_limit == "512Mi"
+        assert config.ephemeral_request is None
+        assert config.ephemeral_limit is None
 
     def test_custom_values(self):
         config = ResourcesConfig(
@@ -156,11 +158,15 @@ class TestResourcesConfig:
             cpu_limit="1",
             memory_request="256Mi",
             memory_limit="1Gi",
+            ephemeral_request="1Gi",
+            ephemeral_limit="2Gi",
         )
         assert config.cpu_request == "200m"
         assert config.cpu_limit == "1"
         assert config.memory_request == "256Mi"
         assert config.memory_limit == "1Gi"
+        assert config.ephemeral_request == "1Gi"
+        assert config.ephemeral_limit == "2Gi"
 
 
 class TestContainerConfig:
@@ -1218,6 +1224,35 @@ class TestArgoBackendSecurityContext:
             assert resources.get("requests", {}).get("memory")
             assert "cpu" not in resources.get("limits", {})
             assert resources.get("limits", {}).get("memory")
+
+    def test_ephemeral_storage_in_generated_workflow(self):
+        """Test that ephemeral storage requests and limits are rendered into the workflow."""
+        config = WorkflowConfig(
+            container=ContainerConfig(
+                resources=ResourcesConfig(
+                    ephemeral_request="1Gi",
+                    ephemeral_limit="2Gi",
+                ),
+            ),
+        )
+        backend = ArgoBackend(config=config)
+        step = DummyStep()
+        yaml_output = backend.generate_artifact(step)
+        workflow = yaml.safe_load(yaml_output)
+
+        spec = workflow.get("spec", {})
+        if "workflowSpec" in spec:
+            templates = spec["workflowSpec"].get("templates", [])
+        else:
+            templates = spec.get("templates", [])
+
+        container_templates = [t for t in templates if "container" in t]
+        assert len(container_templates) > 0
+
+        for template in container_templates:
+            resources = template["container"].get("resources", {})
+            assert resources.get("requests", {}).get("ephemeral-storage") == "1Gi"
+            assert resources.get("limits", {}).get("ephemeral-storage") == "2Gi"
 
     def test_default_node_selector_in_workflow(self):
         """Test that generated workflows select a Kubernetes architecture."""

--- a/tests/backend/test_backend_from_values.py
+++ b/tests/backend/test_backend_from_values.py
@@ -261,6 +261,8 @@ class TestArgoBackendFromValues:
                             "cpu_limit": "1000m",
                             "memory_request": "256Mi",
                             "memory_limit": "1Gi",
+                            "ephemeral_request": "1Gi",
+                            "ephemeral_limit": "2Gi",
                         }
                     },
                 }
@@ -274,6 +276,8 @@ class TestArgoBackendFromValues:
         assert backend.config.container.resources.cpu_limit == "1000m"
         assert backend.config.container.resources.memory_request == "256Mi"
         assert backend.config.container.resources.memory_limit == "1Gi"
+        assert backend.config.container.resources.ephemeral_request == "1Gi"
+        assert backend.config.container.resources.ephemeral_limit == "2Gi"
 
     def test_from_values_generate_artifact(self, tmp_path):
         """Test that ArgoBackend created from values can generate artifacts."""

--- a/wurzel/executors/backend/backend_argo.py
+++ b/wurzel/executors/backend/backend_argo.py
@@ -119,6 +119,8 @@ class ResourcesConfig(BaseModel):
     cpu_limit: str | None = None
     memory_request: str = "128Mi"
     memory_limit: str = "512Mi"
+    ephemeral_request: str | None = None
+    ephemeral_limit: str | None = None
 
 
 class TokenizerCacheConfig(BaseModel):
@@ -394,6 +396,8 @@ class ArgoBackend(Backend, backend_name="argo"):
             cpu_limit=res.cpu_limit,
             memory_request=res.memory_request,
             memory_limit=res.memory_limit,
+            ephemeral_request=res.ephemeral_request,
+            ephemeral_limit=res.ephemeral_limit,
         )
 
     def _build_pod_spec_patch(self) -> str | None:


### PR DESCRIPTION
## Description
Forward ephemeral_request and ephemeral_limit from values YAML through Hera Resources so generated workflows can set ephemeral-storage.


## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run the linter and ensured the code is formatted correctly
- [x] I have updated the documentation accordingly

